### PR TITLE
Add modAL experiment framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,5 +134,15 @@ dmypy.json
 # Training logs
 training/logs
 
+# Local VS Code settings
+.vscode
+
+# Local wandb runs
+wandb/
+
 #deepcode cache
 .dccache
+
+# Data files downloaded by library
+data/downloaded
+data/processed

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ Comparing different active learning strategies for image classification (FSDL co
     - [ResNet Image Classifier](#resnet-image-classifier)
     - [modAL Active Learning Experiment Running Framework](#modal-active-learning-experiment-running-framework)
       - [modAL Sampling Strategy Extensions](#modal-sampling-strategy-extensions)
+        - [Bayesian Uncertainty Sampling](#bayesian-uncertainty-sampling)
+          - [bald](#bald)
+          - [max_entropy](#max_entropy)
+        - [Diversity Sampling](#diversity-sampling)
+          - [outlier](#outlier)
+          - [cluster_outlier_combined](#cluster_outlier_combined)
+        - [Baseline](#baseline)
+          - [random](#random)
   - [Quickstart](#quickstart)
     - [Local](#local)
     - [Google Colab](#google-colab)
@@ -33,6 +41,50 @@ This repository builds upon the template of **lab 08** of the [Full Stack Deep L
 
 The model can be used for transfer learning on the drought prediction data.
 
+### modAL Active Learning Experiment Running Framework
+
+[training/run_modAL_experiment.py](./training/run_modAL_experiment.py): Script to run experiments for model training with different active learning strategies which are implemented via the [modAL library](https://github.com/modAL-python/modAL).
+
+#### modAL Sampling Strategy Extensions
+
+[active_learning/sampling/modal_extensions.py](./active_learning/sampling/modal_extensions.py): Implementation of different sampling strategies for active learning via [modAL library](https://github.com/modAL-python/modAL).
+
+Note that the strategies `bald` and `max_entropy` only make sense when there is a `dropout` layer in the network.
+
+##### Bayesian Uncertainty Sampling
+
+###### bald
+
+Active learning sampling technique that maximizes the information gain via maximising mutual information between predictions and model posterior (Bayesian Active Learning by Disagreement - BALD) as depicted in the papers [Deep Bayesian Active Learning with Image Data](https://arxiv.org/pdf/1703.02910.pdf) and [Bayesian Active Learning for Classification and Preference Learning](https://arxiv.org/pdf/1112.5745.pdf).
+
+###### max_entropy
+
+Active learning sampling technique that maximizes the predictive entropy based on the paper [Deep Bayesian Active Learning with Image Data](https://arxiv.org/pdf/1703.02910.pdf).
+
+##### Diversity Sampling
+
+###### outlier
+
+Self-developed outlier sampling technique:
+
+1. Translates instances from the pool to features by tapping into an intermediate layer of the adapted ResNet model
+2. Performs clustering via HDBSCAN and assigns an outlier score to each instance via GLOSH
+3. Samples instances with highest outlier scores
+
+###### cluster_outlier_combined
+
+Self-developed diversity sampling technique that combines clustering and outliers:
+
+1. Translates instances from the pool to features by tapping into an intermediate layer of the adapted ResNet model
+2. Performs clustering via HDBSCAN and additionally assigns an outlier score to each instance via GLOSH
+3. Samples instances evenly from all clusters, and takes both outlier and non-outlier points by considering the outlier score
+
+##### Baseline
+
+###### random
+
+Baseline active learning sampling technique that takes random instances from available pool.
+
 ## Quickstart
 
 ### Local
@@ -47,6 +99,9 @@ make pip-tools # installs required pip packages inside the conda env
 
 # regular experiment, training a drought watch classifier via pytorch lightning
 python training/run_experiment.py --max_epochs=1 --num_workers=4 --data_class=DroughtWatch --model_class=ResnetClassifier
+
+# active learning experiment with modAL
+python training/run_modaL_experiment.py --al_epochs_init=10 --al_epochs_incr=10 --al_n_iter=20 --al_samples_per_iter=2000 --al_incr_onlynew=False --al_query_strategy=bald --data_class=DroughtWatch --model_class=ResnetClassifier --batch_size=64 --n_train_images=20000 --n_validation_images=10778  --pretrained=True --wandb
 ```
 
 ### Google Colab

--- a/active_learning/sampling/__init__.py
+++ b/active_learning/sampling/__init__.py
@@ -1,0 +1,2 @@
+from .al_sampler import *
+from .modal_extensions import random, max_entropy, bald, outlier, cluster_outlier_combined

--- a/active_learning/sampling/al_sampler.py
+++ b/active_learning/sampling/al_sampler.py
@@ -1,7 +1,6 @@
 import numpy as np
-import torch
 
-def get_random_samples(pool_size,sample_size):
+def get_random_samples(pool_size, sample_size):
     
     #return sample size of random indices 
     if pool_size<=2000:

--- a/active_learning/sampling/modal_extensions.py
+++ b/active_learning/sampling/modal_extensions.py
@@ -1,0 +1,403 @@
+"""
+Implementation of various active learning techniques for the course FSDL Spring 2021 that can be used with modAL.
+"""
+from typing import Tuple
+import torch
+import numpy as np
+import pandas as pd
+from modAL.models import ActiveLearner
+import hdbscan
+from math import ceil
+
+T_DEFAULT = 10
+N_INSTANCES_DEFAULT = 100
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+BATCH_SIZE = 32
+DEBUG_OUTPUT = True
+HDBSCAN_MIN_CLUSTER_SIZE = 500
+OUTLIER_QUANTILE = 0.9
+OUTLIER_FRACTION = 0.2
+EMBEDDING_LAYER = "avgpool"
+EMBEDDING_SIZE = 2048
+
+def max_entropy(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEFAULT, T: int = T_DEFAULT) -> Tuple[torch.Tensor, np.array]:
+    """Active learning sampling technique that maximizes the predictive entropy based on the paper
+    'Deep Bayesian Active Learning with Image Data' (https://arxiv.org/pdf/1703.02910.pdf).
+
+    Examples
+    --------
+    >>> classifier = skorch.NeuralNetClassifier(MyModelClass, ...)
+    >>> learner = modAL.models.ActiveLearner(estimator = classifier, query_strategy = max_entropy, ...) # set max_entropy strategy here
+    >>> query_idx, query_instance = learner.query(sample_pool_X, ...) # strategy is then used here
+    >>> learner.teach(X = sample_pool_X[query_idx], y = sample_pool_y[query_idx], ...)
+
+    Parameters
+    ----------
+    learner : modAL.models.ActiveLearner
+      modAL ActiveLearner instance with which the sampling technique should be used
+
+    X : numpy.array 
+      Array of instances from which to sample from
+
+    n_instances : int (default = 100)
+      Number of instsances that should be sampled
+
+    T : int (default = 10)
+      Number of predictions to generate per X instance from which then the entropy is estimated via taking the mean (see paper for details)
+
+    Returns
+    -------
+    Tuple of indexes and corresponding data instances that were chosen based on the sampling strategy.
+    """
+
+    return _batched_pytorch_tensor_loop(learner, X, n_instances, _max_entropy_scoring_function, T=T)
+
+
+def bald(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEFAULT, T: int = T_DEFAULT) -> Tuple[torch.Tensor, np.array]:
+    """Active learning sampling technique that maximizes the information gain via maximising mutual information between predictions 
+    and model posterior (Bayesian Active Learning by Disagreement - BALD) as depicted in the papers 'Deep Bayesian Active Learning 
+    with Image Data' (https://arxiv.org/pdf/1703.02910.pdf) and 'Bayesian Active Learning for Classification and Preference Learning' 
+    (https://arxiv.org/pdf/1112.5745.pdf).
+
+    Examples
+    --------
+    >>> classifier = skorch.NeuralNetClassifier(MyModelClass, ...)
+    >>> learner = modAL.models.ActiveLearner(estimator = classifier, query_strategy = bald, ...) # set bald strategy here
+    >>> query_idx, query_instance = learner.query(sample_pool_X, ...) # strategy is then used here
+    >>> learner.teach(X = sample_pool_X[query_idx], y = sample_pool_y[query_idx], ...)
+
+    Parameters
+    ----------
+    learner : modAL.models.ActiveLearner
+      modAL ActiveLearner instance with which the sampling technique should be used
+
+    X : numpy.array 
+      Array of instances from which to sample from
+
+    n_instances : int (default = 100)
+      Number of instsances that should be sampled
+
+    T : int (default = 10)
+      Number of predictions to generate per X instance from which then the entropy is estimated via taking the mean (see paper for details)
+
+    Returns
+    -------
+    Tuple of indexes and corresponding data instances that were chosen based on the sampling strategy.
+    """
+
+    return _batched_pytorch_tensor_loop(learner, X, n_instances, _bald_scoring_function, T=T)
+
+
+def random(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEFAULT) -> Tuple[torch.Tensor, np.array]:
+    """Baseline active learning sampling technique that takes random instances from available pool.
+
+    Examples
+    --------
+    >>> classifier = skorch.NeuralNetClassifier(MyModelClass, ...)
+    >>> learner = modAL.models.ActiveLearner(estimator = classifier, query_strategy = random, ...) # set random strategy here
+    >>> query_idx, query_instance = learner.query(sample_pool_X, ...) # strategy is then used here
+    >>> learner.teach(X = sample_pool_X[query_idx], y = sample_pool_y[query_idx], ...)
+
+    Parameters
+    ----------
+    learner : modAL.models.ActiveLearner
+      modAL ActiveLearner instance with which the sampling technique should be used
+
+    X : numpy.array 
+      Array of instances from which to sample from
+
+    n_instances : int (default = 100)
+      Number of instsances that should be sampled
+
+    Returns
+    -------
+    Tuple of indexes and corresponding data instances that were chosen based on the sampling strategy.
+    """
+    
+    query_idx = np.random.choice(range(len(X)), size=n_instances, replace=False)
+    return query_idx, X[query_idx]
+
+
+def _batched_pytorch_tensor_loop(learner, X, n_instances, batch_scoring_function, **kwargs): 
+
+    if DEBUG_OUTPUT:
+        print("Processing pool of instances with selected active learning strategy...")
+        print("(Note: Based on the pool size this takes a while. Will generate debug output every 10%.)")
+        ten_percent = int(len(X)/BATCH_SIZE/10)
+        i = 0
+        percentage_output = 10
+
+    # initialize pytorch tensor to store acquisition scores
+    all_acquisitions = torch.Tensor().to(DEVICE)
+
+    # create pytorch dataloader for batch-wise processing
+    all_samples = torch.utils.data.DataLoader(X, batch_size=BATCH_SIZE)
+
+    # process pool of instances batch wise
+    for batch in all_samples:
+
+        acquisitions = batch_scoring_function(learner, batch, **kwargs)
+        
+        all_acquisitions = torch.cat([all_acquisitions, acquisitions])
+
+        if DEBUG_OUTPUT:
+            i += 1
+            if i > ten_percent:
+                print(f"{percentage_output}% of samples in pool processed")
+                percentage_output += 10
+                i = 0
+
+    # collect first n_instances to cpu and return
+    idx = torch.argsort(-all_acquisitions)[:n_instances].cpu()
+    return idx, X[idx]
+
+
+def _bald_scoring_function(learner, batch, T):
+
+    with torch.no_grad():
+
+        outputs = torch.stack([
+            torch.softmax( # probabilities from logits
+                learner.estimator.forward(batch, training=True, device=DEVICE), dim=-1) # logits
+            for t in range(T) # multiple calculations to average over
+            ])
+
+    mean_outputs = torch.mean(outputs, dim=0)
+
+    H = torch.sum(-mean_outputs*torch.log(mean_outputs + 1e-10), dim=-1)
+    E_H = - torch.mean(torch.sum(outputs * torch.log(outputs + 1e-10), dim=-1), dim=0)
+    acquisitions = H - E_H
+
+    return acquisitions
+
+
+def _max_entropy_scoring_function(learner, batch, T):
+
+    with torch.no_grad():
+
+        outputs = torch.stack([
+            torch.softmax( # probabilities from logits
+                learner.estimator.forward(batch, training=True, device=DEVICE), dim=-1) # logits
+            for t in range(T) # multiple calculations to average over
+            ])
+
+    mean_outputs = torch.mean(outputs, dim=0)
+
+    acquisitions = torch.sum((-mean_outputs * torch.log(mean_outputs + 1e-10)), dim=-1)
+    return acquisitions
+
+
+def _featurize_instances(learner, X):
+    if DEBUG_OUTPUT:
+        print("Featurizing pool of instances for diversity sampling...")
+        print("(Note: Based on the pool size this takes a while. Will generate debug output every 10%.)")
+        ten_percent = int(len(X)/BATCH_SIZE/10)
+        i = 0
+        percentage_output = 10
+
+    # initialize pytorch tensor to store features
+    all_features = torch.Tensor().to(DEVICE)
+
+    # create pytorch dataloader for batch-wise processing
+    all_samples = torch.utils.data.DataLoader(X, batch_size=BATCH_SIZE)
+
+    # add hook to model that generates our features
+    layer = learner.estimator.module.resnet._modules.get(EMBEDDING_LAYER)
+    batch_features = torch.zeros(BATCH_SIZE, EMBEDDING_SIZE, 1, 1).to(DEVICE)
+
+    def copy_data(m, i, o):
+        batch_features.copy_(o.data)
+
+    hook = layer.register_forward_hook(copy_data)     
+
+    # process pool of instances batch wise to featurize
+    for batch in all_samples:
+
+        # if last batch smaller: avoid size mismatch
+        if batch.shape[0] < BATCH_SIZE:
+            batch_features = torch.zeros(batch.shape[0], EMBEDDING_SIZE, 1, 1)
+        
+        # feed batch into network (get out features via registered hook)
+        _ = learner.estimator.forward(batch, training=False, device=DEVICE)
+
+        all_features = torch.cat([all_features, batch_features], dim=0)
+
+        if DEBUG_OUTPUT:
+            i += 1
+            if i > 2:
+                break 
+            if i > ten_percent:
+                print(f"{percentage_output}% of samples in pool featurized")
+                percentage_output += 10
+                i = 0
+
+    hook.remove()
+
+    all_features = all_features.squeeze().cpu().numpy()
+
+    return all_features
+
+
+def _cluster_instances(all_features, min_cluster_size):
+    if DEBUG_OUTPUT:
+        print("Performing clustering...")
+
+    # perform clustering
+    n_clusters = -1
+    while n_clusters < 1:
+        clusterer = hdbscan.HDBSCAN(min_cluster_size=min_cluster_size).fit(all_features)
+        n_clusters = clusterer.labels_.max()+1
+        if n_clusters < 1:
+            if DEBUG_OUTPUT:
+                print(f"HDBSCAN was not able to find clusters, halving min. cluster size from {min_cluster_size} to {int(min_cluster_size/2)}")
+            min_cluster_size = int(min_cluster_size/2)
+
+    return clusterer, n_clusters
+
+
+def outlier(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEFAULT, min_cluster_size: int = HDBSCAN_MIN_CLUSTER_SIZE) -> Tuple[torch.Tensor, np.array]:
+    """Active learning sampling technique that translates instances from the pool to features by using an internal layer of the
+    learner model as featurizer, performing HDBSCAN to cluster the instances and then returning the outliers based on their
+    GLOSH score.
+
+    Examples
+    --------
+    >>> classifier = skorch.NeuralNetClassifier(MyModelClass, ...)
+    >>> learner = modAL.models.ActiveLearner(estimator = classifier, query_strategy = outlier, ...) # set outlier strategy here
+    >>> query_idx, query_instance = learner.query(sample_pool_X, ...) # strategy is then used here
+    >>> learner.teach(X = sample_pool_X[query_idx], y = sample_pool_y[query_idx], ...)
+
+    Parameters
+    ----------
+    learner : modAL.models.ActiveLearner
+      modAL ActiveLearner instance with which the sampling technique should be used
+
+    X : numpy.array 
+      Array of instances from which to sample from
+
+    n_instances : int (default = 100)
+      Number of instsances that should be sampled
+
+    min_cluster_size : int (default = 100)
+      Minimum number of points inside one cluster (used for HDBSCAN clustering algorithm)
+
+
+    Returns
+    -------
+    Tuple of indexes and corresponding data instances that were chosen based on the sampling strategy.
+    """
+
+    all_features = _featurize_instances(learner, X)
+
+    clusterer, _ = _cluster_instances(all_features, min_cluster_size)
+
+    # select indices with highest outlier scores and return them
+    idx = np.argsort(-clusterer.outlier_scores_)[:n_instances]
+    return idx, X[idx]
+
+
+def cluster_outlier_combined(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEFAULT, min_cluster_size: int = HDBSCAN_MIN_CLUSTER_SIZE) -> Tuple[torch.Tensor, np.array]:
+    """Active learning sampling technique that translates instances from the pool to features by using an internal layer of the
+    learner model as featurizer, performing HDBSCAN to cluster the instances and then returning a combination of instances spread 
+    across all clusters and outliers detected via GLOSH.
+
+    Examples
+    --------
+    >>> classifier = skorch.NeuralNetClassifier(MyModelClass, ...)
+    >>> learner = modAL.models.ActiveLearner(estimator = classifier, query_strategy = cluster_outlier_combined, ...) # set cluster_outlier_combined strategy here
+    >>> query_idx, query_instance = learner.query(sample_pool_X, ...) # strategy is then used here
+    >>> learner.teach(X = sample_pool_X[query_idx], y = sample_pool_y[query_idx], ...)
+
+    Parameters
+    ----------
+    learner : modAL.models.ActiveLearner
+      modAL ActiveLearner instance with which the sampling technique should be used
+
+    X : numpy.array 
+      Array of instances from which to sample from
+
+    n_instances : int (default = 100)
+      Number of instsances that should be sampled
+
+    min_cluster_size : int (default = 100)
+      Minimum number of points inside one cluster (used for HDBSCAN clustering algorithm)
+
+
+    Returns
+    -------
+    Tuple of indexes and corresponding data instances that were chosen based on the sampling strategy.
+    """
+
+    all_features = _featurize_instances(learner, X)
+
+    clusterer, n_clusters = _cluster_instances(all_features, min_cluster_size)
+
+    # initialize variables needed below
+    outlier_threshold = pd.Series(clusterer.outlier_scores_).quantile(OUTLIER_QUANTILE)
+    n_features = len(all_features)
+    instances_per_cluster = int(n_instances/n_clusters)
+    all_selected_idx = np.array([]).astype(int)
+
+    # check whether distribution between clusters can be done even - if not, distribute remaining equally
+    if n_instances % n_clusters != 0:
+        leftover_instances = n_instances-instances_per_cluster*n_clusters
+    else:
+        leftover_instances = 0
+
+    if DEBUG_OUTPUT:
+        print(f"{n_clusters} clusters found, entering loop to pick instances in all of them...")
+    
+    # loop over clusters to select instances in all of them
+    for cluster_id in range(n_clusters):
+
+        # distribute remaining instances if needed
+        if leftover_instances > 0:
+            remaining_clusters = n_clusters - cluster_id
+            additional_instances = ceil((leftover_instances / remaining_clusters))
+            instances_in_cluster = instances_per_cluster + additional_instances
+            leftover_instances -= additional_instances
+        else:
+            instances_in_cluster = instances_per_cluster
+
+        n_outliers = int(instances_in_cluster*OUTLIER_FRACTION)
+        n_regular = instances_in_cluster-n_outliers
+
+        # limit pool to current cluster only
+        cluster_idx_all = np.where(clusterer.labels_ == cluster_id)[0]
+        regular_idx_all = np.where(clusterer.outlier_scores_[cluster_idx_all] < outlier_threshold)[0]
+        outlier_idx_all = np.where(clusterer.outlier_scores_[cluster_idx_all] >= outlier_threshold)[0]
+
+        # avoid having a pool that is too small to sample from
+        if len(regular_idx_all) < n_regular:
+            leftover_instances += (n_regular-len(regular_idx_all))
+            n_regular = len(regular_idx_all)
+        if len(outlier_idx_all) < n_outliers:
+            leftover_instances += (n_outliers-len(outlier_idx_all))
+            n_outliers = len(outlier_idx_all)
+
+        # select both regular and outlier instances for this cluster
+        regular_idx_selected = np.random.choice(len(regular_idx_all), size=n_regular, replace=False)      
+        outlier_idx_selected = np.random.choice(len(outlier_idx_all), size=n_outliers, replace=False)
+
+        # calculate all idx that are selected from this cluster
+        if n_outliers > 0:
+            outlier_idx_original = np.array(range(n_features))[cluster_idx_all][outlier_idx_all][outlier_idx_selected] # outlier idx of this cluster (idx translated to full pool)
+        else:
+            outlier_idx_original = np.array([]).astype(int)
+
+        if n_regular > 0:
+            regular_idx_original = np.array(range(n_features))[cluster_idx_all][regular_idx_all][regular_idx_selected] # regular idx of this cluster (idx translated to full pool)
+        else:
+            regular_idx_original = np.array([]).astype(int)
+
+        cluster_idx_selected = np.concatenate([outlier_idx_original, regular_idx_original])
+
+        all_selected_idx = np.concatenate([all_selected_idx, cluster_idx_selected])
+
+        if DEBUG_OUTPUT:
+            print(f"Instance selection on cluster no. {cluster_id} done.")
+
+    if len(all_selected_idx) < n_instances:
+        print(f"CAUTION: cluster_outlier_combined algorithm was not able to build a set of {n_instances} instances as requested, instead only returning {len(all_selected_idx)} instances.")
+
+    return all_selected_idx, X[all_selected_idx]

--- a/active_learning/sampling/modal_extensions.py
+++ b/active_learning/sampling/modal_extensions.py
@@ -20,7 +20,10 @@ OUTLIER_FRACTION = 0.2
 EMBEDDING_LAYER = "avgpool"
 EMBEDDING_SIZE = 2048
 
-def max_entropy(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEFAULT, T: int = T_DEFAULT) -> Tuple[torch.Tensor, np.array]:
+
+def max_entropy(
+    learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEFAULT, T: int = T_DEFAULT
+) -> Tuple[torch.Tensor, np.array]:
     """Active learning sampling technique that maximizes the predictive entropy based on the paper
     'Deep Bayesian Active Learning with Image Data' (https://arxiv.org/pdf/1703.02910.pdf).
 
@@ -36,7 +39,7 @@ def max_entropy(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTAN
     learner : modAL.models.ActiveLearner
       modAL ActiveLearner instance with which the sampling technique should be used
 
-    X : numpy.array 
+    X : numpy.array
       Array of instances from which to sample from
 
     n_instances : int (default = 100)
@@ -53,10 +56,12 @@ def max_entropy(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTAN
     return _batched_pytorch_tensor_loop(learner, X, n_instances, _max_entropy_scoring_function, T=T)
 
 
-def bald(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEFAULT, T: int = T_DEFAULT) -> Tuple[torch.Tensor, np.array]:
-    """Active learning sampling technique that maximizes the information gain via maximising mutual information between predictions 
-    and model posterior (Bayesian Active Learning by Disagreement - BALD) as depicted in the papers 'Deep Bayesian Active Learning 
-    with Image Data' (https://arxiv.org/pdf/1703.02910.pdf) and 'Bayesian Active Learning for Classification and Preference Learning' 
+def bald(
+    learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEFAULT, T: int = T_DEFAULT
+) -> Tuple[torch.Tensor, np.array]:
+    """Active learning sampling technique that maximizes the information gain via maximising mutual information between predictions
+    and model posterior (Bayesian Active Learning by Disagreement - BALD) as depicted in the papers 'Deep Bayesian Active Learning
+    with Image Data' (https://arxiv.org/pdf/1703.02910.pdf) and 'Bayesian Active Learning for Classification and Preference Learning'
     (https://arxiv.org/pdf/1112.5745.pdf).
 
     Examples
@@ -71,7 +76,7 @@ def bald(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEF
     learner : modAL.models.ActiveLearner
       modAL ActiveLearner instance with which the sampling technique should be used
 
-    X : numpy.array 
+    X : numpy.array
       Array of instances from which to sample from
 
     n_instances : int (default = 100)
@@ -88,7 +93,9 @@ def bald(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEF
     return _batched_pytorch_tensor_loop(learner, X, n_instances, _bald_scoring_function, T=T)
 
 
-def random(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEFAULT) -> Tuple[torch.Tensor, np.array]:
+def random(
+    learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEFAULT
+) -> Tuple[torch.Tensor, np.array]:
     """Baseline active learning sampling technique that takes random instances from available pool.
 
     Examples
@@ -103,7 +110,7 @@ def random(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_D
     learner : modAL.models.ActiveLearner
       modAL ActiveLearner instance with which the sampling technique should be used
 
-    X : numpy.array 
+    X : numpy.array
       Array of instances from which to sample from
 
     n_instances : int (default = 100)
@@ -113,17 +120,17 @@ def random(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_D
     -------
     Tuple of indexes and corresponding data instances that were chosen based on the sampling strategy.
     """
-    
+
     query_idx = np.random.choice(range(len(X)), size=n_instances, replace=False)
     return query_idx, X[query_idx]
 
 
-def _batched_pytorch_tensor_loop(learner, X, n_instances, batch_scoring_function, **kwargs): 
+def _batched_pytorch_tensor_loop(learner, X, n_instances, batch_scoring_function, **kwargs):
 
     if DEBUG_OUTPUT:
         print("Processing pool of instances with selected active learning strategy...")
         print("(Note: Based on the pool size this takes a while. Will generate debug output every 10%.)")
-        ten_percent = int(len(X)/BATCH_SIZE/10)
+        ten_percent = int(len(X) / BATCH_SIZE / 10)
         i = 0
         percentage_output = 10
 
@@ -137,7 +144,7 @@ def _batched_pytorch_tensor_loop(learner, X, n_instances, batch_scoring_function
     for batch in all_samples:
 
         acquisitions = batch_scoring_function(learner, batch, **kwargs)
-        
+
         all_acquisitions = torch.cat([all_acquisitions, acquisitions])
 
         if DEBUG_OUTPUT:
@@ -156,16 +163,19 @@ def _bald_scoring_function(learner, batch, T):
 
     with torch.no_grad():
 
-        outputs = torch.stack([
-            torch.softmax( # probabilities from logits
-                learner.estimator.forward(batch, training=True, device=DEVICE), dim=-1) # logits
-            for t in range(T) # multiple calculations to average over
-            ])
+        outputs = torch.stack(
+            [
+                torch.softmax(  # probabilities from logits
+                    learner.estimator.forward(batch, training=True, device=DEVICE), dim=-1
+                )  # logits
+                for t in range(T)  # multiple calculations to average over
+            ]
+        )
 
     mean_outputs = torch.mean(outputs, dim=0)
 
-    H = torch.sum(-mean_outputs*torch.log(mean_outputs + 1e-10), dim=-1)
-    E_H = - torch.mean(torch.sum(outputs * torch.log(outputs + 1e-10), dim=-1), dim=0)
+    H = torch.sum(-mean_outputs * torch.log(mean_outputs + 1e-10), dim=-1)
+    E_H = -torch.mean(torch.sum(outputs * torch.log(outputs + 1e-10), dim=-1), dim=0)
     acquisitions = H - E_H
 
     return acquisitions
@@ -175,11 +185,14 @@ def _max_entropy_scoring_function(learner, batch, T):
 
     with torch.no_grad():
 
-        outputs = torch.stack([
-            torch.softmax( # probabilities from logits
-                learner.estimator.forward(batch, training=True, device=DEVICE), dim=-1) # logits
-            for t in range(T) # multiple calculations to average over
-            ])
+        outputs = torch.stack(
+            [
+                torch.softmax(  # probabilities from logits
+                    learner.estimator.forward(batch, training=True, device=DEVICE), dim=-1
+                )  # logits
+                for t in range(T)  # multiple calculations to average over
+            ]
+        )
 
     mean_outputs = torch.mean(outputs, dim=0)
 
@@ -191,7 +204,7 @@ def _featurize_instances(learner, X):
     if DEBUG_OUTPUT:
         print("Featurizing pool of instances for diversity sampling...")
         print("(Note: Based on the pool size this takes a while. Will generate debug output every 10%.)")
-        ten_percent = int(len(X)/BATCH_SIZE/10)
+        ten_percent = int(len(X) / BATCH_SIZE / 10)
         i = 0
         percentage_output = 10
 
@@ -208,7 +221,7 @@ def _featurize_instances(learner, X):
     def copy_data(m, i, o):
         batch_features.copy_(o.data)
 
-    hook = layer.register_forward_hook(copy_data)     
+    hook = layer.register_forward_hook(copy_data)
 
     # process pool of instances batch wise to featurize
     for batch in all_samples:
@@ -216,7 +229,7 @@ def _featurize_instances(learner, X):
         # if last batch smaller: avoid size mismatch
         if batch.shape[0] < BATCH_SIZE:
             batch_features = torch.zeros(batch.shape[0], EMBEDDING_SIZE, 1, 1)
-        
+
         # feed batch into network (get out features via registered hook)
         _ = learner.estimator.forward(batch, training=False, device=DEVICE)
 
@@ -225,7 +238,7 @@ def _featurize_instances(learner, X):
         if DEBUG_OUTPUT:
             i += 1
             if i > 2:
-                break 
+                break
             if i > ten_percent:
                 print(f"{percentage_output}% of samples in pool featurized")
                 percentage_output += 10
@@ -246,16 +259,23 @@ def _cluster_instances(all_features, min_cluster_size):
     n_clusters = -1
     while n_clusters < 1:
         clusterer = hdbscan.HDBSCAN(min_cluster_size=min_cluster_size).fit(all_features)
-        n_clusters = clusterer.labels_.max()+1
+        n_clusters = clusterer.labels_.max() + 1
         if n_clusters < 1:
             if DEBUG_OUTPUT:
-                print(f"HDBSCAN was not able to find clusters, halving min. cluster size from {min_cluster_size} to {int(min_cluster_size/2)}")
-            min_cluster_size = int(min_cluster_size/2)
+                print(
+                    f"HDBSCAN was not able to find clusters, halving min. cluster size from {min_cluster_size} to {int(min_cluster_size/2)}"
+                )
+            min_cluster_size = int(min_cluster_size / 2)
 
     return clusterer, n_clusters
 
 
-def outlier(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEFAULT, min_cluster_size: int = HDBSCAN_MIN_CLUSTER_SIZE) -> Tuple[torch.Tensor, np.array]:
+def outlier(
+    learner: ActiveLearner,
+    X: np.array,
+    n_instances: int = N_INSTANCES_DEFAULT,
+    min_cluster_size: int = HDBSCAN_MIN_CLUSTER_SIZE,
+) -> Tuple[torch.Tensor, np.array]:
     """Active learning sampling technique that translates instances from the pool to features by using an internal layer of the
     learner model as featurizer, performing HDBSCAN to cluster the instances and then returning the outliers based on their
     GLOSH score.
@@ -272,7 +292,7 @@ def outlier(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_
     learner : modAL.models.ActiveLearner
       modAL ActiveLearner instance with which the sampling technique should be used
 
-    X : numpy.array 
+    X : numpy.array
       Array of instances from which to sample from
 
     n_instances : int (default = 100)
@@ -296,9 +316,14 @@ def outlier(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_
     return idx, X[idx]
 
 
-def cluster_outlier_combined(learner: ActiveLearner, X: np.array, n_instances: int = N_INSTANCES_DEFAULT, min_cluster_size: int = HDBSCAN_MIN_CLUSTER_SIZE) -> Tuple[torch.Tensor, np.array]:
+def cluster_outlier_combined(
+    learner: ActiveLearner,
+    X: np.array,
+    n_instances: int = N_INSTANCES_DEFAULT,
+    min_cluster_size: int = HDBSCAN_MIN_CLUSTER_SIZE,
+) -> Tuple[torch.Tensor, np.array]:
     """Active learning sampling technique that translates instances from the pool to features by using an internal layer of the
-    learner model as featurizer, performing HDBSCAN to cluster the instances and then returning a combination of instances spread 
+    learner model as featurizer, performing HDBSCAN to cluster the instances and then returning a combination of instances spread
     across all clusters and outliers detected via GLOSH.
 
     Examples
@@ -313,7 +338,7 @@ def cluster_outlier_combined(learner: ActiveLearner, X: np.array, n_instances: i
     learner : modAL.models.ActiveLearner
       modAL ActiveLearner instance with which the sampling technique should be used
 
-    X : numpy.array 
+    X : numpy.array
       Array of instances from which to sample from
 
     n_instances : int (default = 100)
@@ -335,18 +360,18 @@ def cluster_outlier_combined(learner: ActiveLearner, X: np.array, n_instances: i
     # initialize variables needed below
     outlier_threshold = pd.Series(clusterer.outlier_scores_).quantile(OUTLIER_QUANTILE)
     n_features = len(all_features)
-    instances_per_cluster = int(n_instances/n_clusters)
+    instances_per_cluster = int(n_instances / n_clusters)
     all_selected_idx = np.array([]).astype(int)
 
     # check whether distribution between clusters can be done even - if not, distribute remaining equally
     if n_instances % n_clusters != 0:
-        leftover_instances = n_instances-instances_per_cluster*n_clusters
+        leftover_instances = n_instances - instances_per_cluster * n_clusters
     else:
         leftover_instances = 0
 
     if DEBUG_OUTPUT:
         print(f"{n_clusters} clusters found, entering loop to pick instances in all of them...")
-    
+
     # loop over clusters to select instances in all of them
     for cluster_id in range(n_clusters):
 
@@ -359,8 +384,8 @@ def cluster_outlier_combined(learner: ActiveLearner, X: np.array, n_instances: i
         else:
             instances_in_cluster = instances_per_cluster
 
-        n_outliers = int(instances_in_cluster*OUTLIER_FRACTION)
-        n_regular = instances_in_cluster-n_outliers
+        n_outliers = int(instances_in_cluster * OUTLIER_FRACTION)
+        n_regular = instances_in_cluster - n_outliers
 
         # limit pool to current cluster only
         cluster_idx_all = np.where(clusterer.labels_ == cluster_id)[0]
@@ -369,24 +394,28 @@ def cluster_outlier_combined(learner: ActiveLearner, X: np.array, n_instances: i
 
         # avoid having a pool that is too small to sample from
         if len(regular_idx_all) < n_regular:
-            leftover_instances += (n_regular-len(regular_idx_all))
+            leftover_instances += n_regular - len(regular_idx_all)
             n_regular = len(regular_idx_all)
         if len(outlier_idx_all) < n_outliers:
-            leftover_instances += (n_outliers-len(outlier_idx_all))
+            leftover_instances += n_outliers - len(outlier_idx_all)
             n_outliers = len(outlier_idx_all)
 
         # select both regular and outlier instances for this cluster
-        regular_idx_selected = np.random.choice(len(regular_idx_all), size=n_regular, replace=False)      
+        regular_idx_selected = np.random.choice(len(regular_idx_all), size=n_regular, replace=False)
         outlier_idx_selected = np.random.choice(len(outlier_idx_all), size=n_outliers, replace=False)
 
         # calculate all idx that are selected from this cluster
         if n_outliers > 0:
-            outlier_idx_original = np.array(range(n_features))[cluster_idx_all][outlier_idx_all][outlier_idx_selected] # outlier idx of this cluster (idx translated to full pool)
+            outlier_idx_original = np.array(range(n_features))[cluster_idx_all][outlier_idx_all][
+                outlier_idx_selected
+            ]  # outlier idx of this cluster (idx translated to full pool)
         else:
             outlier_idx_original = np.array([]).astype(int)
 
         if n_regular > 0:
-            regular_idx_original = np.array(range(n_features))[cluster_idx_all][regular_idx_all][regular_idx_selected] # regular idx of this cluster (idx translated to full pool)
+            regular_idx_original = np.array(range(n_features))[cluster_idx_all][regular_idx_all][
+                regular_idx_selected
+            ]  # regular idx of this cluster (idx translated to full pool)
         else:
             regular_idx_original = np.array([]).astype(int)
 
@@ -398,6 +427,8 @@ def cluster_outlier_combined(learner: ActiveLearner, X: np.array, n_instances: i
             print(f"Instance selection on cluster no. {cluster_id} done.")
 
     if len(all_selected_idx) < n_instances:
-        print(f"CAUTION: cluster_outlier_combined algorithm was not able to build a set of {n_instances} instances as requested, instead only returning {len(all_selected_idx)} instances.")
+        print(
+            f"CAUTION: cluster_outlier_combined algorithm was not able to build a set of {n_instances} instances as requested, instead only returning {len(all_selected_idx)} instances."
+        )
 
     return all_selected_idx, X[all_selected_idx]

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -18,3 +18,5 @@ scipy
 pillow
 wandb
 modAL
+skorch
+hdbscan

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -61,6 +61,8 @@ contextvars==2.4
     # via sniffio
 cycler==0.10.0
     # via matplotlib
+cython==0.29.23
+    # via hdbscan
 dataclasses==0.8
     # via
     #   -c requirements/prod.txt
@@ -88,6 +90,8 @@ gitpython==3.1.14
     # via
     #   bandit
     #   wandb
+hdbscan==0.8.27
+    # via -r requirements/dev.in
 idna==2.10
     # via
     #   -c requirements/prod.txt
@@ -132,6 +136,7 @@ jinja2==2.11.3
     #   notebook
 joblib==1.0.1
     # via
+    #   hdbscan
     #   nltk
     #   scikit-learn
 json5==0.9.5
@@ -214,13 +219,14 @@ notebook==6.3.0
 numpy==1.19.5
     # via
     #   -c requirements/prod.txt
+    #   hdbscan
     #   itermplot
     #   matplotlib
     #   modal
     #   pandas
     #   scikit-learn
     #   scipy
-    #   tfrecord
+    #   skorch
 packaging==20.9
     # via
     #   bleach
@@ -264,7 +270,6 @@ prompt-toolkit==3.0.18
 protobuf==3.15.7
     # via
     #   -c requirements/prod.txt
-    #   tfrecord
     #   wandb
 psutil==5.8.0
     # via wandb
@@ -330,12 +335,17 @@ requests==2.25.1
 safety==1.10.3
     # via -r requirements/dev.in
 scikit-learn==0.24.1
-    # via modal
+    # via
+    #   hdbscan
+    #   modal
+    #   skorch
 scipy==1.5.4
     # via
     #   -r requirements/dev.in
+    #   hdbscan
     #   modal
     #   scikit-learn
+    #   skorch
 send2trash==1.5.0
     # via
     #   jupyter-server
@@ -352,6 +362,7 @@ six==1.15.0
     #   bleach
     #   cycler
     #   docker-pycreds
+    #   hdbscan
     #   itermplot
     #   jsonschema
     #   promise
@@ -359,6 +370,8 @@ six==1.15.0
     #   python-dateutil
     #   traitlets
     #   wandb
+skorch==0.10.0
+    # via -r requirements/dev.in
 smmap==4.0.0
     # via gitdb
 sniffio==1.2.0
@@ -369,14 +382,14 @@ stevedore==3.3.0
     # via bandit
 subprocess32==3.5.4
     # via wandb
+tabulate==0.8.9
+    # via skorch
 terminado==0.9.4
     # via
     #   jupyter-server
     #   notebook
 testpath==0.4.4
     # via nbconvert
-tfrecord==1.12
-    # via -r requirements/dev.in
 threadpoolctl==2.1.0
     # via scikit-learn
 toml==0.10.2
@@ -399,6 +412,7 @@ tqdm==4.59.0
     # via
     #   -c requirements/prod.txt
     #   nltk
+    #   skorch
 traitlets==4.3.3
     # via
     #   ipykernel

--- a/training/run_experiment.py
+++ b/training/run_experiment.py
@@ -11,7 +11,7 @@ from PIL import Image
 
 
 from active_learning import lit_models
-from active_learning.data import al_sampler # for active learning sampling 
+from active_learning.sampling import al_sampler # for active learning sampling 
 from torch.utils.data import ConcatDataset, DataLoader
 
 

--- a/training/run_modal_experiment.py
+++ b/training/run_modal_experiment.py
@@ -18,12 +18,14 @@ from active_learning import lit_models
 np.random.seed(42)
 torch.manual_seed(42)
 
+
 def _import_class(module_and_class_name: str) -> type:
     """Import class from a module, e.g. 'active_learning.models.MLP'"""
     module_name, class_name = module_and_class_name.rsplit(".", 1)
     module = importlib.import_module(module_name)
     class_ = getattr(module, class_name)
     return class_
+
 
 def _setup_parser():
     """Set up Python's ArgumentParser with data, model, trainer, and other arguments."""
@@ -56,37 +58,81 @@ def _setup_parser():
     lit_models.BaseLitModel.add_to_argparse(lit_model_group)
 
     # Active learning specific arguments
-    parser.add_argument("--al_epochs_init", type=int, default=20, help="No. of initial epochs to train before beginning with active learning")
-    parser.add_argument("--al_epochs_incr", type=int, default=20, help="No. of epochs to train in each active learning iteration")
+    parser.add_argument(
+        "--al_epochs_init",
+        type=int,
+        default=20,
+        help="No. of initial epochs to train before beginning with active learning",
+    )
+    parser.add_argument(
+        "--al_epochs_incr", type=int, default=20, help="No. of epochs to train in each active learning iteration"
+    )
     parser.add_argument("--al_n_iter", type=int, default=33, help="No. of active learning iterations")
-    parser.add_argument("--al_samples_per_iter", type=int, default=2000, help="No. of samples to query per active learning iteration")
-    parser.add_argument("--al_incr_onlynew", type=bool, default=False, help="Whether to take only newly queried samples in each active learning iterations, or the full training data")
-    parser.add_argument("--al_query_strategy", type=str, choices=["uncertainty_sampling", "margin_sampling", "entropy_sampling", "max_entropy", "bald", "random", "outlier", "cluster_outlier_combined"], default="uncertainty_sampling", help="Active learning query strategy")
+    parser.add_argument(
+        "--al_samples_per_iter", type=int, default=2000, help="No. of samples to query per active learning iteration"
+    )
+    parser.add_argument(
+        "--al_incr_onlynew",
+        type=bool,
+        default=False,
+        help="Whether to take only newly queried samples in each active learning iterations, or the full training data",
+    )
+    parser.add_argument(
+        "--al_query_strategy",
+        type=str,
+        choices=[
+            "uncertainty_sampling",
+            "margin_sampling",
+            "entropy_sampling",
+            "max_entropy",
+            "bald",
+            "random",
+            "outlier",
+            "cluster_outlier_combined",
+        ],
+        default="uncertainty_sampling",
+        help="Active learning query strategy",
+    )
 
     # For debugging / development purposes
-    parser.add_argument("--reduced_develop_train_size", type=bool, default=False, help="Whether to take only a very small set to train (allows for faster results during development)")
+    parser.add_argument(
+        "--reduced_develop_train_size",
+        type=bool,
+        default=False,
+        help="Whether to take only a very small set to train (allows for faster results during development)",
+    )
 
     parser.add_argument("--help", "-h", action="help")
     return parser
 
-def _log_skorch_history(history: skorch.history.History, al_iter: int, epoch_start: int, train_acc: float, train_size: int, wandb_logging: bool = True) -> None:
 
-    for epoch, train_loss, valid_loss, valid_acc, dur in history[:, ('epoch', 'train_loss', 'valid_loss', 'valid_acc', 'dur')]:
+def _log_skorch_history(
+    history: skorch.history.History,
+    al_iter: int,
+    epoch_start: int,
+    train_acc: float,
+    train_size: int,
+    wandb_logging: bool = True,
+) -> None:
+
+    for epoch, train_loss, valid_loss, valid_acc, dur in history[
+        :, ("epoch", "train_loss", "valid_loss", "valid_acc", "dur")
+    ]:
 
         metrics = {
-            'epoch': epoch_start + epoch, 
-            'train_loss': train_loss, 
-            'valid_loss': valid_loss, 
-            'valid_acc': valid_acc, 
-            'dur': dur,
-            'al_iter': al_iter, 
+            "epoch": epoch_start + epoch,
+            "train_loss": train_loss,
+            "valid_loss": valid_loss,
+            "valid_acc": valid_acc,
+            "dur": dur,
+            "al_iter": al_iter,
         }
-                
-        # add train_acc to last item of history
-        if epoch == len(history[:, 'train_loss']):
-            metrics['train_acc'] = train_acc
 
-        #print(metrics)
+        # add train_acc to last item of history
+        if epoch == len(history[:, "train_loss"]):
+            metrics["train_acc"] = train_acc
+
+        # print(metrics)
         if wandb_logging:
             wandb.log(metrics)
 
@@ -97,7 +143,7 @@ def main():
 
     Sample command:
     ```
-    python training/run_modAL_experiment.py --al_epochs_init=10 --al_epochs_incr=5 --al_n_iter=10 --al_samples_per_iter=100 --data_class=DroughtWatch --model_class=ResnetClassifier --batch_size=64 --n_train_images=1000 --n_validation_images=1000 --pretrained=True --wandb 
+    python training/run_modAL_experiment.py --al_epochs_init=10 --al_epochs_incr=5 --al_n_iter=10 --al_samples_per_iter=100 --data_class=DroughtWatch --model_class=ResnetClassifier --batch_size=64 --n_train_images=1000 --n_validation_images=1000 --pretrained=True --wandb
     ```
     """
 
@@ -127,7 +173,6 @@ def main():
 
     logger = pl.loggers.TensorBoardLogger("training/logs")
 
-
     # modAL specific experiment setup
     # -------------------------------
 
@@ -143,31 +188,34 @@ def main():
         query_strategy = _import_class(f"active_learning.sampling.{args.al_query_strategy}")
 
     # cpu vs. gpu: ignore --gpu args param, instead just set gpu based on availability
-    device = "cuda" if torch.cuda.is_available() else "cpu" 
+    device = "cuda" if torch.cuda.is_available() else "cpu"
 
-     # initialize train, validation and pool datasets
+    # initialize train, validation and pool datasets
     data.setup()
 
-    X_initial = np.moveaxis(data.data_train.data, 3, 1) # shape change: (i, channels, h, w) instead of (i, h, w, channels)
+    X_initial = np.moveaxis(
+        data.data_train.data, 3, 1
+    )  # shape change: (i, channels, h, w) instead of (i, h, w, channels)
     y_initial = data.data_train.targets
     if args.reduced_develop_train_size:
         print("NOTE: Reduced initial train set size for development activated")
         X_initial = X_initial[:100, :, :, :]
         y_initial = y_initial[:100]
 
-    X_val = np.moveaxis(data.data_val.data, 3, 1) # shape change
+    X_val = np.moveaxis(data.data_val.data, 3, 1)  # shape change
     y_val = data.data_val.targets
-    X_pool = np.moveaxis(data.data_unlabelled.data, 3, 1) # shape change
+    X_pool = np.moveaxis(data.data_unlabelled.data, 3, 1)  # shape change
     y_pool = data.data_unlabelled.targets
 
     # initialize skorch classifier
-    classifier = NeuralNetClassifier(model,
-                                     criterion=torch.nn.CrossEntropyLoss,
-                                     optimizer=torch.optim.Adam,
-                                     train_split=predefined_split(Dataset(X_val, y_val)),
-                                     verbose=1,
-                                     device=device,
-                                     )
+    classifier = NeuralNetClassifier(
+        model,
+        criterion=torch.nn.CrossEntropyLoss,
+        optimizer=torch.optim.Adam,
+        train_split=predefined_split(Dataset(X_val, y_val)),
+        verbose=1,
+        device=device,
+    )
 
     lit_model.summarize(mode="full")
 
@@ -175,36 +223,38 @@ def main():
     print("Initializing model with base training set")
     learner = ActiveLearner(
         estimator=classifier,
-        X_training=X_initial, 
-        y_training=y_initial, 
+        X_training=X_initial,
+        y_training=y_initial,
         epochs=args.al_epochs_init,
-        query_strategy=query_strategy
+        query_strategy=query_strategy,
     )
 
     _log_skorch_history(
-        history = learner.estimator.history, 
-        al_iter = 0, 
-        epoch_start = 0, 
-        train_acc = learner.score(learner.X_training, learner.y_training),
-        train_size = len(learner.y_training),
-        wandb_logging = args.wandb)
+        history=learner.estimator.history,
+        al_iter=0,
+        epoch_start=0,
+        train_acc=learner.score(learner.X_training, learner.y_training),
+        train_size=len(learner.y_training),
+        wandb_logging=args.wandb,
+    )
 
     # active learning loop
     for idx in range(args.al_n_iter):
 
-        print('Active learning query no. %d' % (idx + 1))
+        print("Active learning query no. %d" % (idx + 1))
         query_idx, _ = learner.query(X_pool, n_instances=args.al_samples_per_iter)
         learner.teach(
             X=X_pool[query_idx], y=y_pool[query_idx], only_new=args.al_incr_onlynew, epochs=args.al_epochs_incr
         )
 
         _log_skorch_history(
-            history = learner.estimator.history, 
-            al_iter = idx+1, 
-            epoch_start = args.al_epochs_init + idx*args.al_epochs_incr, 
-            train_acc = learner.score(learner.X_training, learner.y_training),
-            train_size = len(learner.y_training),
-            wandb_logging = args.wandb)
+            history=learner.estimator.history,
+            al_iter=idx + 1,
+            epoch_start=args.al_epochs_init + idx * args.al_epochs_incr,
+            train_acc=learner.score(learner.X_training, learner.y_training),
+            train_size=len(learner.y_training),
+            wandb_logging=args.wandb,
+        )
 
         # remove queried instances from pool
         X_pool = np.delete(X_pool, query_idx, axis=0)

--- a/training/run_modal_experiment.py
+++ b/training/run_modal_experiment.py
@@ -1,0 +1,215 @@
+"""modAL experiment-running framework."""
+import argparse
+import importlib
+import numpy as np
+import torch
+import pytorch_lightning as pl
+import wandb
+
+from modAL.models import ActiveLearner
+import skorch
+from skorch import NeuralNetClassifier
+from skorch.helper import predefined_split
+from skorch.dataset import Dataset
+
+from active_learning import lit_models
+
+# In order to ensure reproducible experiments, we must set random seeds.
+np.random.seed(42)
+torch.manual_seed(42)
+
+def _import_class(module_and_class_name: str) -> type:
+    """Import class from a module, e.g. 'active_learning.models.MLP'"""
+    module_name, class_name = module_and_class_name.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    class_ = getattr(module, class_name)
+    return class_
+
+def _setup_parser():
+    """Set up Python's ArgumentParser with data, model, trainer, and other arguments."""
+    parser = argparse.ArgumentParser(add_help=False)
+
+    # Add Trainer specific arguments, such as --max_epochs, --gpus, --precision
+    trainer_parser = pl.Trainer.add_argparse_args(parser)
+    trainer_parser._action_groups[1].title = "Trainer Args"  # pylint: disable=protected-access
+    parser = argparse.ArgumentParser(add_help=False, parents=[trainer_parser])
+
+    # Basic arguments
+    parser.add_argument("--wandb", action="store_true", default=False)
+    parser.add_argument("--data_class", type=str, default="MNIST")
+    parser.add_argument("--model_class", type=str, default="MLP")
+    parser.add_argument("--load_checkpoint", type=str, default=None)
+
+    # Get the data and model classes, so that we can add their specific arguments
+    temp_args, _ = parser.parse_known_args()
+    data_class = _import_class(f"active_learning.data.{temp_args.data_class}")
+    model_class = _import_class(f"active_learning.models.{temp_args.model_class}")
+
+    # Get data, model, and LitModel specific arguments
+    data_group = parser.add_argument_group("Data Args")
+    data_class.add_to_argparse(data_group)
+
+    model_group = parser.add_argument_group("Model Args")
+    model_class.add_to_argparse(model_group)
+
+    lit_model_group = parser.add_argument_group("LitModel Args")
+    lit_models.BaseLitModel.add_to_argparse(lit_model_group)
+
+    # Active learning specific arguments
+    parser.add_argument("--al_epochs_init", type=int, default=20, help="No. of initial epochs to train before beginning with active learning")
+    parser.add_argument("--al_epochs_incr", type=int, default=20, help="No. of epochs to train in each active learning iteration")
+    parser.add_argument("--al_n_iter", type=int, default=33, help="No. of active learning iterations")
+    parser.add_argument("--al_samples_per_iter", type=int, default=2000, help="No. of samples to query per active learning iteration")
+    parser.add_argument("--al_incr_onlynew", type=bool, default=False, help="Whether to take only newly queried samples in each active learning iterations, or the full training data")
+    parser.add_argument("--al_query_strategy", type=str, choices=["uncertainty_sampling", "margin_sampling", "entropy_sampling", "max_entropy", "bald", "random", "outlier", "cluster_outlier_combined"], default="uncertainty_sampling", help="Active learning query strategy")
+
+    # For debugging / development purposes
+    parser.add_argument("--reduced_develop_train_size", type=bool, default=False, help="Whether to take only a very small set to train (allows for faster results during development)")
+
+    parser.add_argument("--help", "-h", action="help")
+    return parser
+
+def _log_skorch_history(history: skorch.history.History, al_iter: int, epoch_start: int, train_acc: float, train_size: int, wandb_logging: bool = True) -> None:
+
+    for epoch, train_loss, valid_loss, valid_acc, dur in history[:, ('epoch', 'train_loss', 'valid_loss', 'valid_acc', 'dur')]:
+
+        metrics = {
+            'epoch': epoch_start + epoch, 
+            'train_loss': train_loss, 
+            'valid_loss': valid_loss, 
+            'valid_acc': valid_acc, 
+            'dur': dur,
+            'al_iter': al_iter, 
+        }
+                
+        # add train_acc to last item of history
+        if epoch == len(history[:, 'train_loss']):
+            metrics['train_acc'] = train_acc
+
+        #print(metrics)
+        if wandb_logging:
+            wandb.log(metrics)
+
+
+def main():
+    """
+    Run an active learning experiment.
+
+    Sample command:
+    ```
+    python training/run_modAL_experiment.py --al_epochs_init=10 --al_epochs_incr=5 --al_n_iter=10 --al_samples_per_iter=100 --data_class=DroughtWatch --model_class=ResnetClassifier --batch_size=64 --n_train_images=1000 --n_validation_images=1000 --pretrained=True --wandb 
+    ```
+    """
+
+    # generic setup steps from run_experiment
+    # ---------------------------------------
+
+    parser = _setup_parser()
+    args = parser.parse_args()
+    data_class = _import_class(f"active_learning.data.{args.data_class}")
+    model_class = _import_class(f"active_learning.models.{args.model_class}")
+    data = data_class(args)
+    model = model_class(data_config=data.config(), args=args)
+
+    if args.loss not in ("ctc", "transformer"):
+        lit_model_class = lit_models.BaseLitModel
+
+    if args.loss == "ctc":
+        lit_model_class = lit_models.CTCLitModel
+
+    if args.loss == "transformer":
+        lit_model_class = lit_models.TransformerLitModel
+
+    if args.load_checkpoint is not None:
+        lit_model = lit_model_class.load_from_checkpoint(args.load_checkpoint, args=args, model=model)
+    else:
+        lit_model = lit_model_class(args=args, model=model)
+
+    logger = pl.loggers.TensorBoardLogger("training/logs")
+
+
+    # modAL specific experiment setup
+    # -------------------------------
+
+    # initialize wandb with pytorch model
+    if args.wandb:
+        wandb.init(config=args)
+        wandb.watch(model, log_freq=100)
+
+    # evaluate query strategy from args parameter
+    if args.al_query_strategy in ["uncertainty_sampling", "margin_sampling", "entropy_sampling"]:
+        query_strategy = _import_class(f"modAL.uncertainty.{args.al_query_strategy}")
+    else:
+        query_strategy = _import_class(f"active_learning.sampling.{args.al_query_strategy}")
+
+    # cpu vs. gpu: ignore --gpu args param, instead just set gpu based on availability
+    device = "cuda" if torch.cuda.is_available() else "cpu" 
+
+     # initialize train, validation and pool datasets
+    data.setup()
+
+    X_initial = np.moveaxis(data.data_train.data, 3, 1) # shape change: (i, channels, h, w) instead of (i, h, w, channels)
+    y_initial = data.data_train.targets
+    if args.reduced_develop_train_size:
+        print("NOTE: Reduced initial train set size for development activated")
+        X_initial = X_initial[:100, :, :, :]
+        y_initial = y_initial[:100]
+
+    X_val = np.moveaxis(data.data_val.data, 3, 1) # shape change
+    y_val = data.data_val.targets
+    X_pool = np.moveaxis(data.data_unlabelled.data, 3, 1) # shape change
+    y_pool = data.data_unlabelled.targets
+
+    # initialize skorch classifier
+    classifier = NeuralNetClassifier(model,
+                                     criterion=torch.nn.CrossEntropyLoss,
+                                     optimizer=torch.optim.Adam,
+                                     train_split=predefined_split(Dataset(X_val, y_val)),
+                                     verbose=1,
+                                     device=device,
+                                     )
+
+    lit_model.summarize(mode="full")
+
+    # initialize modal active learner
+    print("Initializing model with base training set")
+    learner = ActiveLearner(
+        estimator=classifier,
+        X_training=X_initial, 
+        y_training=y_initial, 
+        epochs=args.al_epochs_init,
+        query_strategy=query_strategy
+    )
+
+    _log_skorch_history(
+        history = learner.estimator.history, 
+        al_iter = 0, 
+        epoch_start = 0, 
+        train_acc = learner.score(learner.X_training, learner.y_training),
+        train_size = len(learner.y_training),
+        wandb_logging = args.wandb)
+
+    # active learning loop
+    for idx in range(args.al_n_iter):
+
+        print('Active learning query no. %d' % (idx + 1))
+        query_idx, _ = learner.query(X_pool, n_instances=args.al_samples_per_iter)
+        learner.teach(
+            X=X_pool[query_idx], y=y_pool[query_idx], only_new=args.al_incr_onlynew, epochs=args.al_epochs_incr
+        )
+
+        _log_skorch_history(
+            history = learner.estimator.history, 
+            al_iter = idx+1, 
+            epoch_start = args.al_epochs_init + idx*args.al_epochs_incr, 
+            train_acc = learner.score(learner.X_training, learner.y_training),
+            train_size = len(learner.y_training),
+            wandb_logging = args.wandb)
+
+        # remove queried instances from pool
+        X_pool = np.delete(X_pool, query_idx, axis=0)
+        y_pool = np.delete(y_pool, query_idx, axis=0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add separate `run_modal_experiment.py` routine that allows to run active learning experiments using the modAL library and extensions written for it.

Sampling methods included in this PR:
- baseline
  - random
- bayesian uncertainty
  - dropout + entropy
  - dropout + disagreement (BALD)
- diversity
  - outliers (via HDBSCAN/GLOSH)
  - outlier/clustering combination (via HDBSCAN/GLOSH)

The existing submodule `al_sampler` was moved from `actice_learning.data` to `active_learning.sampling` in order to have a common place and store it alongside the modAL additions named `modal_extensions`