### PR TITLE
Expand experiment framework for MC based sampling methods + refactor main experiment routine slightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,26 @@ Comparing different active learning strategies for image classification (FSDL co
   - [Relevant Changes Compared to Lab Template](#relevant-changes-compared-to-lab-template)
     - [DroughtWatch Data Set](#droughtwatch-data-set)
     - [ResNet Image Classifier](#resnet-image-classifier)
+    - [Main Active Learning Experiment Running Framework](#main-active-learning-experiment-running-framework)
+      - [Uncertainty Sampling](#uncertainty-sampling)
+        - [least_confidence](#least_confidence)
+        - [margin](#margin)
+        - [ratio](#ratio)
+        - [entropy](#entropy)
+      - [Bayesian Uncertainty Sampling](#bayesian-uncertainty-sampling)
+        - [bald](#bald)
+        - [max_entropy](#max_entropy)
+      - [Baseline](#baseline)
+        - [random](#random)
     - [modAL Active Learning Experiment Running Framework](#modal-active-learning-experiment-running-framework)
-      - [modAL Sampling Strategy Extensions](#modal-sampling-strategy-extensions)
-        - [Bayesian Uncertainty Sampling](#bayesian-uncertainty-sampling)
-          - [bald](#bald)
-          - [max_entropy](#max_entropy)
-        - [Diversity Sampling](#diversity-sampling)
-          - [outlier](#outlier)
-          - [cluster_outlier_combined](#cluster_outlier_combined)
-        - [Baseline](#baseline)
-          - [random](#random)
+      - [Bayesian Uncertainty Sampling](#bayesian-uncertainty-sampling-1)
+        - [bald](#bald-1)
+        - [max_entropy](#max_entropy-1)
+      - [Diversity Sampling](#diversity-sampling)
+        - [outlier](#outlier)
+        - [cluster_outlier_combined](#cluster_outlier_combined)
+      - [Baseline](#baseline-1)
+        - [random](#random-1)
   - [Quickstart](#quickstart)
     - [Local](#local)
     - [Google Colab](#google-colab)
@@ -41,29 +51,49 @@ This repository builds upon the template of **lab 08** of the [Full Stack Deep L
 
 The model can be used for transfer learning on the drought prediction data.
 
+### Main Active Learning Experiment Running Framework
+
+[training/run_experiment.py](./training/run_experiment.py): Script to run experiments for model training with different active learning strategies which are implemented in the separate submodule [active_learning/sampling/al_sampler.py](./active_learning/sampling/al_sampler.py).
+
+#### Uncertainty Sampling
+
+##### least_confidence
+
+##### margin
+
+##### ratio
+
+##### entropy
+
+#### Bayesian Uncertainty Sampling
+
+##### bald
+
+##### max_entropy
+
+#### Baseline
+
+##### random
+
 ### modAL Active Learning Experiment Running Framework
 
-[training/run_modAL_experiment.py](./training/run_modAL_experiment.py): Script to run experiments for model training with different active learning strategies which are implemented via the [modAL library](https://github.com/modAL-python/modAL).
-
-#### modAL Sampling Strategy Extensions
-
-[active_learning/sampling/modal_extensions.py](./active_learning/sampling/modal_extensions.py): Implementation of different sampling strategies for active learning via [modAL library](https://github.com/modAL-python/modAL).
+[training/run_modAL_experiment.py](./training/run_modal_experiment.py): Script to run experiments for model training with different active learning strategies which are implemented via the [modAL library](https://github.com/modAL-python/modAL). The modAL extensions are bundled under the submodule [active_learning/sampling/modal_extensions.py](./active_learning/sampling/modal_extensions.py).
 
 Note that the strategies `bald` and `max_entropy` only make sense when there is a `dropout` layer in the network.
 
-##### Bayesian Uncertainty Sampling
+#### Bayesian Uncertainty Sampling
 
-###### bald
+##### bald
 
 Active learning sampling technique that maximizes the information gain via maximising mutual information between predictions and model posterior (Bayesian Active Learning by Disagreement - BALD) as depicted in the papers [Deep Bayesian Active Learning with Image Data](https://arxiv.org/pdf/1703.02910.pdf) and [Bayesian Active Learning for Classification and Preference Learning](https://arxiv.org/pdf/1112.5745.pdf).
 
-###### max_entropy
+##### max_entropy
 
 Active learning sampling technique that maximizes the predictive entropy based on the paper [Deep Bayesian Active Learning with Image Data](https://arxiv.org/pdf/1703.02910.pdf).
 
-##### Diversity Sampling
+#### Diversity Sampling
 
-###### outlier
+##### outlier
 
 Self-developed outlier sampling technique:
 
@@ -71,7 +101,7 @@ Self-developed outlier sampling technique:
 2. Performs clustering via HDBSCAN and assigns an outlier score to each instance via GLOSH
 3. Samples instances with highest outlier scores
 
-###### cluster_outlier_combined
+##### cluster_outlier_combined
 
 Self-developed diversity sampling technique that combines clustering and outliers:
 
@@ -79,9 +109,9 @@ Self-developed diversity sampling technique that combines clustering and outlier
 2. Performs clustering via HDBSCAN and additionally assigns an outlier score to each instance via GLOSH
 3. Samples instances evenly from all clusters, and takes both outlier and non-outlier points by considering the outlier score
 
-##### Baseline
+#### Baseline
 
-###### random
+##### random
 
 Baseline active learning sampling technique that takes random instances from available pool.
 
@@ -97,8 +127,8 @@ make conda-update # creates a conda env with the base packages
 conda activate fsdl-active-learning-2021 # activates the conda env
 make pip-tools # installs required pip packages inside the conda env
 
-# regular experiment, training a drought watch classifier via pytorch lightning
-python training/run_experiment.py --max_epochs=1 --num_workers=4 --data_class=DroughtWatch --model_class=ResnetClassifier
+# active learning experiment
+python training/run_experiment.py --sampling_method=max_entropy --data_class=DroughtWatch --model_class=ResnetClassifier --batch_size=64 --gpus=1 --max_epochs=20
 
 # active learning experiment with modAL
 python training/run_modaL_experiment.py --al_epochs_init=10 --al_epochs_incr=10 --al_n_iter=20 --al_samples_per_iter=2000 --al_incr_onlynew=False --al_query_strategy=bald --data_class=DroughtWatch --model_class=ResnetClassifier --batch_size=64 --n_train_images=20000 --n_validation_images=10778  --pretrained=True --wandb

--- a/active_learning/sampling/al_sampler.py
+++ b/active_learning/sampling/al_sampler.py
@@ -1,77 +1,117 @@
 import numpy as np
+import torch
 
-def get_random_samples(pool_size, sample_size):
-    
-    #return sample size of random indices 
-    if pool_size<=2000:
-        indices=[x for x in range(pool_size)]  #return complete pool size 
+
+def random(predictions, sample_size):
+
+    pool_size = len(predictions)
+
+    # return sample size of random indices
+    if pool_size <= 2000:
+        indices = [x for x in range(pool_size)]  # return complete pool size
     else:
-        indices=np.random.randint(pool_size, size=sample_size)
+        indices = np.random.randint(pool_size, size=sample_size)
 
     return indices
 
-def get_least_confidence_samples(predictions, sample_size):
+
+def least_confidence(predictions, sample_size):
 
     conf = []
     indices = []
-    for idx,prediction in enumerate(predictions):
+
+    for idx, prediction in enumerate(predictions):
         most_confident = np.max(prediction)
-        n_classes=prediction.shape[0]
-        conf_score=(1-most_confident)*n_classes/(n_classes-1)
+        n_classes = prediction.shape[0]
+        conf_score = (1 - most_confident) * n_classes / (n_classes - 1)
         conf.append(conf_score)
         indices.append(idx)
-            
+
     conf = np.asarray(conf)
     indices = np.asarray(indices)
-    result=indices[np.argsort(conf)][:sample_size]
-    
-        
+    result = indices[np.argsort(conf)][:sample_size]
+
     return result
 
-def get_top2_confidence_margin_samples(predictions, sample_size):
 
-    
+def margin(predictions, sample_size):
+
     margins = []
     indices = []
-        
-    for idx,predxn in enumerate(predictions):
+
+    for idx, predxn in enumerate(predictions):
         predxn[::-1].sort()
-        margin=predxn[0]-predxn[1]
+        margin = predxn[0] - predxn[1]
         margins.append(margin)
         indices.append(idx)
-    margins=np.asarray(margins)
-    indices=np.asarray(indices)
-    least_margin_indices=indices[np.argsort(margins)][:sample_size]
-  
+    margins = np.asarray(margins)
+    indices = np.asarray(indices)
+    least_margin_indices = indices[np.argsort(margins)][:sample_size]
+
     return least_margin_indices
 
-def get_top2_confidence_ratio_samples(predictions, sample_size):
 
-    
+def ratio(predictions, sample_size):
+
     margins = []
     indices = []
-        
-    for idx,predxn in enumerate(predictions):
-        predxn[::-1].sort()
-        margins.append(predxn[1]/predxn[0])
-        indices.append(idx)
-    margins=np.asarray(margins)
-    indices=np.asarray(indices)
-    confidence_ratio_indices=indices[np.argsort(margins)][:sample_size]
-  
-    return confidence_ratio_indices 
 
-def get_entropy_samples(predictions,sample_size):
+    for idx, predxn in enumerate(predictions):
+        predxn[::-1].sort()
+        margins.append(predxn[1] / predxn[0])
+        indices.append(idx)
+    margins = np.asarray(margins)
+    indices = np.asarray(indices)
+    confidence_ratio_indices = indices[np.argsort(margins)][:sample_size]
+
+    return confidence_ratio_indices
+
+
+def entropy(predictions, sample_size):
+
     entropies = []
     indices = []
-    for idx,predxn in enumerate(predictions):
-        log2p=np.log2(predxn)
-        pxlog2p=predxn * log2p
-        n=len(predxn)
-        entropy=-np.sum(pxlog2p)/np.log2(n)
+
+    for idx, predxn in enumerate(predictions):
+        log2p = np.log2(predxn)
+        pxlog2p = predxn * log2p
+        n = len(predxn)
+        entropy = -np.sum(pxlog2p) / np.log2(n)
         entropies.append(entropy)
         indices.append(idx)
-    entropies=np.asarray(entropies)
-    indices=np.asarray(indices)
-    max_entropy_indices=np.argsort(entropies)[-sample_size:]  
-    return max_entropy_indices     
+    entropies = np.asarray(entropies)
+    indices = np.asarray(indices)
+    max_entropy_indices = np.argsort(entropies)[-sample_size:]
+
+    return max_entropy_indices
+
+
+def bald(probabilities: torch.Tensor, sample_size: int) -> np.array:
+    """Active learning sampling technique that maximizes the information gain via maximising mutual information between predictions
+    and model posterior (Bayesian Active Learning by Disagreement - BALD) as depicted in the papers 'Deep Bayesian Active Learning
+    with Image Data' (https://arxiv.org/pdf/1703.02910.pdf) and 'Bayesian Active Learning for Classification and Preference Learning'
+    (https://arxiv.org/pdf/1112.5745.pdf).
+    """
+
+    mean_probabilities = torch.mean(probabilities, dim=-1)
+
+    H = torch.sum(-mean_probabilities * torch.log(mean_probabilities + 1e-10), dim=-1)
+    E_H = -torch.mean(torch.sum(probabilities * torch.log(probabilities + 1e-10), dim=-1), dim=-1)
+
+    scores = H - E_H
+
+    idx = torch.argsort(-scores)[:sample_size].cpu().numpy()
+    return idx
+
+
+def max_entropy(probabilities: torch.Tensor, sample_size: int) -> np.array:
+    """Active learning sampling technique that maximizes the predictive entropy based on the paper 'Deep Bayesian Active Learning
+    with Image Data' (https://arxiv.org/pdf/1703.02910.pdf).
+    """
+
+    mean_probabilities = torch.mean(probabilities, dim=2)
+
+    scores = torch.sum((-mean_probabilities * torch.log(mean_probabilities + 1e-10)), dim=-1)
+
+    idx = torch.argsort(-scores)[:sample_size].cpu().numpy()
+    return idx

--- a/training/run_experiment.py
+++ b/training/run_experiment.py
@@ -6,18 +6,16 @@ import numpy as np
 import torch
 import pytorch_lightning as pl
 import wandb
-import h5py
-from PIL import Image
-
 
 from active_learning import lit_models
-from active_learning.sampling import al_sampler # for active learning sampling 
-from torch.utils.data import ConcatDataset, DataLoader
-
 
 # In order to ensure reproducible experiments, we must set random seeds.
 np.random.seed(42)
 torch.manual_seed(42)
+
+DEBUG_OUTPUT = True
+MC_SAMPLING_METHODS = ["bald", "max_entropy"]
+MC_ITERATIONS = 10
 
 
 def _import_class(module_and_class_name: str) -> type:
@@ -38,13 +36,11 @@ def _setup_parser():
     parser = argparse.ArgumentParser(add_help=False, parents=[trainer_parser])
 
     # Basic arguments
-    # Hide lines below until Lab 5
     parser.add_argument("--wandb", action="store_true", default=False)
-    # Hide lines above until Lab 5
     parser.add_argument("--data_class", type=str, default="DroughtWatch")
     parser.add_argument("--model_class", type=str, default="ResnetClassifier")
     parser.add_argument("--load_checkpoint", type=str, default=None)
-    parser.add_argument("--sampling_method", type=str, default='random')
+    parser.add_argument("--sampling_method", type=str, default="random")
 
     # Get the data and model classes, so that we can add their specific arguments
     temp_args, _ = parser.parse_known_args()
@@ -78,127 +74,83 @@ def main():
     args = parser.parse_args()
     data_class = _import_class(f"active_learning.data.{args.data_class}")
     model_class = _import_class(f"active_learning.models.{args.model_class}")
-    
+
     data = data_class(args)
-    
     model = model_class(data_config=data.config(), args=args)
-    sampling_method=args.sampling_method
+
+    sampling_method = args.sampling_method
+    sampling_class = _import_class(f"active_learning.sampling.al_sampler.{sampling_method}")
 
     lit_model_class = lit_models.BaseLitModel
-    
 
     if args.load_checkpoint is not None:
         lit_model = lit_model_class.load_from_checkpoint(args.load_checkpoint, args=args, model=model)
     else:
         lit_model = lit_model_class(args=args, model=model)
 
-    #logger = pl.loggers.TensorBoardLogger("training/logs")
-    # Hide lines below until Lab 5
-    #if args.wandb:
-    project_name='fsdl-active-learning_'+sampling_method
-    logger = pl.loggers.WandbLogger(name=project_name,project='fsdl-active-learning', job_type='train')
+    # --wandb args parameter ignored for now, always using wandb
+    project_name = "fsdl-active-learning_" + sampling_method
+    logger = pl.loggers.WandbLogger(name=project_name, project="fsdl-active-learning", job_type="train")
     logger.watch(model)
     logger.log_hyperparams(vars(args))
-    # Hide lines above until Lab 5
 
     early_stopping_callback = pl.callbacks.EarlyStopping(monitor="val_loss", mode="min", patience=10)
     model_checkpoint_callback = pl.callbacks.ModelCheckpoint(
         filename="{epoch:03d}-{val_loss:.3f}-{val_cer:.3f}", monitor="val_loss", mode="min"
     )
-    
+
     callbacks = [early_stopping_callback, model_checkpoint_callback]
 
     args.weights_summary = None  # Don't Print full summary of the model # "full"
     trainer = pl.Trainer.from_argparse_args(args, callbacks=callbacks, logger=logger, weights_save_path="training/logs")
-    
-    unlabelled_data_size=data.get_ds_length(ds_name='unlabelled')
-    # pylint: disable=no-member
+
+    unlabelled_data_size = data.get_ds_length(ds_name="unlabelled")
     trainer.tune(lit_model, datamodule=data)  # If passing --auto_lr_find, this will set learning rate
+    
+    while unlabelled_data_size > 1000:
 
-    while (unlabelled_data_size>1000):
-
-        
-
+        # fit model on current data
         trainer.fit(lit_model, datamodule=data)
-        #reset predictions array of model 
-        lit_model.reset_predictions()
-        #run a test loop so that we can get the model predictions 
-        trainer.test(lit_model, datamodule=data)
-        #get model predictions 
-        predictions = lit_model.predictions # maybe use a getPredictions method instead of referencing directly
-        
-        # now you can get indices for samples to be labelled using the al_sampler methods 
 
-        # get random samples 
-        # sample_size is the number of samples you need for labelling
-        # pool_size is the size of the unlabelled pool size data.get_ds_length('unlabelled')
-        
-        if unlabelled_data_size>2000:
-            sample_size=2000 # take 2000 extra samples at a time #int(0.25 * unlabelled_data_size)
+        # if pool is large enough, take 2000 new samples - otherwise take all remaining ones
+        if unlabelled_data_size > 2000:
+            sample_size = 2000
         else:
-            sample_size=unlabelled_data_size    
-        print('Total Unlabelled Pool Size ', unlabelled_data_size)
-        print('Query Sample size ',sample_size)
+            sample_size = unlabelled_data_size
 
-        if sampling_method=='random':
-                
-            
-            new_indices= al_sampler.get_random_samples(pool_size=unlabelled_data_size,sample_size=sample_size)
-            '''
-            print('Random indices for labelling : \n-----------------\n') 
+        print("Total Unlabelled Pool Size ", unlabelled_data_size)
+        print("Query Sample size ", sample_size)
+
+        if sampling_method not in MC_SAMPLING_METHODS:
+
+            # reset predictions array of model
+            lit_model.reset_predictions()
+
+            # run a test loop so that we can get the model predictions and get model predictions
+            trainer.test(lit_model, datamodule=data)
+            predictions = lit_model.predictions  # maybe use a getPredictions method instead of referencing directly
+
+            # get indices for samples to be labelled using the al_sampler methods
+            new_indices = sampling_class(predictions, sample_size)
+
+        else:
+
+            # predict multiple times with model in 'training' mode (dropout activated)
+            probabilities = data.get_pool_probabilities(lit_model, T=MC_ITERATIONS)
+
+            new_indices = sampling_class(probabilities, sample_size)
+
+        if DEBUG_OUTPUT:
+            print(f'Indices selected for labelling via method "{sampling_method}": \n-----------------\n')
             print(new_indices)
-            print('\n-----------------\n') 
-            '''
-        elif sampling_method=='least_confidence':
-                
-            # Get Least confidence samples 
-            #pass predictions and sample size as args
-            new_indices=al_sampler.get_least_confidence_samples(predictions,sample_size=sample_size)
-            
-            '''
-            print('Least confidence query indices for labelling : \n-----------------\n') 
-            print(new_indices) 
-            print('\n-----------------\n')   
-            '''
+            print("\n-----------------\n")
 
-        elif sampling_method=='margin':
-                
-
-            # Get Top 2 Margin samples 
-            #pass predictions and sample size as args
-            new_indices=al_sampler.get_top2_confidence_margin_samples(predictions,sample_size=sample_size) 
-            '''
-            print('Top2 confidence margin samples : \n-------------------\n')
-            print(new_indices)
-            print('\n-----------------\n')
-            '''
-        elif sampling_method=='ratio':
-                       
-            new_indices=al_sampler.get_top2_confidence_ratio_samples(predictions,sample_size=sample_size) 
-
-        elif sampling_method=='entropy':
-                       
-            new_indices=al_sampler.get_entropy_samples(predictions,sample_size=sample_size)     
-
-
-
-        #adjust training set and unlabelled pool based on new queried indices 
-        
+        # adjust training set and unlabelled pool based on new queried indices
         data.expand_training_set(new_indices)
-        unlabelled_data_size=data.get_ds_length(ds_name='unlabelled')
+        unlabelled_data_size = data.get_ds_length(ds_name="unlabelled")
 
-        # pylint: enable=no-member
-        '''
-        # Hide lines below until Lab 5
-        best_model_path = model_checkpoint_callback.best_model_path
-        if best_model_path:
-            print("Best model saved at:", best_model_path)
-            if args.wandb:
-                wandb.save(best_model_path)
-                print("Best model also uploaded to W&B")
-        # Hide lines above until Lab 5
-        '''
-    wandb.finish()    
+    wandb.finish()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Main:
- Add MC experiment framework:
  - Separate logic in `run_experiment.py`
  - Helper method `get_pool_probabilities` in `DroughtWatch` module to predict multiple times (could also be included in `BaseDataModule` as it's meant to be a general method - same applies probably to ` expand_training_set`). Was not able to use built-in `test` or `predict` here because I was not have dropout activated while using them
  - Two methods `bald` and `max_entropy` implemented, similarly to modAL framework
  - Helper args parameter `reduced_pool` only for development purposes

Refactoring:
- Refactor `run_experiment.py` and `al_sampler.py`: 
  - Rename al_sampler classes to match the args strings that define the method to be used
  - Instead of switch with `if` statements and string comparisons, automatically import method based on args string
- `al_sampler.py` has a lot of changed lines because of pretty formatting via black (sorry 😊 )