### PR TITLE
channel normalization fixed, binary and rgb params improved

### DIFF
--- a/active_learning/data/droughtwatch.py
+++ b/active_learning/data/droughtwatch.py
@@ -46,8 +46,8 @@ class DroughtWatch(BaseDataModule):
         parser.add_argument("--n_train_images", type=int, default=N_TRAIN)
         parser.add_argument("--n_validation_images", type=int, default=N_VAL)
         parser.add_argument("--bands", type=str, default=",".join(BANDS))
-        parser.add_argument("--binary", type=bool, default=BINARY)
-        parser.add_argument("--rgb", type=bool, default=RGB)
+        parser.add_argument('--binary', action='store_true', help="Whether to run binary classification experiment (default is multi-class)")
+        parser.add_argument('--rgb', action='store_true', help="Whether to include RGB channels only (default is all 11 channels)")
         parser.add_argument("--reduced_pool", type=bool, default=False, help="Whether to take only a fraction of the pool (allows for faster results during development)")
         return parser
 

--- a/active_learning/models/resnet_classifier.py
+++ b/active_learning/models/resnet_classifier.py
@@ -4,6 +4,7 @@ import torch
 import torch.nn as nn
 import torchvision.transforms as tt
 import torchvision
+import warnings
 
 PRETRAINED = True
 NUM_CLASSES = 4
@@ -39,15 +40,26 @@ class ResnetClassifier(nn.Module):
         # base ResNet model
         self.resnet = torchvision.models.resnet50(pretrained=pretrained)
 
-        # preprocessing steps to resize images (adapted from https://pytorch.org/hub/pytorch_vision_resnet/)
-        new_channel_mean = 0.485 # from existing channel 0
-        new_channel_std = 0.229 # from existing channel 0
-        self.preprocess = tt.Compose([
+        # preprocessing for standard RGB images
+        if rgb == True:
+            self.preprocess = tt.Compose([
                     tt.Resize(224),
                     tt.Normalize(
-                    mean=[0.485, 0.456, 0.406] + [new_channel_mean]*(n_channels-3), 
-                    std=[0.229, 0.224, 0.225] + [new_channel_std]*(n_channels-3))
+                    mean=[0.485, 0.456, 0.406], 
+                    std=[0.229, 0.224, 0.225])
                 ])
+        
+        # preprocessing steps to resize images (adapted from https://pytorch.org/hub/pytorch_vision_resnet/)
+        else:
+            warnings.warn("Image normalization assumes RGB channels correspond to channels 3,2,1")
+            new_channel_mean = 0.485 # from existing channel 0
+            new_channel_std = 0.229 # from existing channel 0
+            self.preprocess = tt.Compose([
+                        tt.Resize(224),
+                        tt.Normalize(
+                        mean=[new_channel_mean] + [0.406, 0.456, 0.485] + [new_channel_mean]*(n_channels-4), 
+                        std=[new_channel_std] + [0.225, 0.224, 0.229] + [new_channel_std]*(n_channels-4))
+                    ])
 
         # changing the architecture of the laster layers
         # if dropout is activated, add an additional fully connected layer with dropout before the last layer


### PR DESCRIPTION
Changes in droughtwatch.py:
- changed --binary and --rgb params from binary to "store_true"

Changes in resnet_classifier.py:
- import warnings
- add normalization for RGB images
- fix normalization for 11 channel images (order of RGB channels)