### PR TITLE
adding model based outliers sampling

### DIFF
--- a/active_learning/lit_models/base.py
+++ b/active_learning/lit_models/base.py
@@ -75,8 +75,8 @@ class BaseLitModel(pl.LightningModule):  # pylint: disable=too-many-ancestors
         )
         return {"optimizer": optimizer, "lr_scheduler": scheduler, "monitor": "val_loss"}
 
-    def forward(self, x):
-        return self.model(x)
+    def forward(self, x, **kwargs):
+        return self.model(x, **kwargs)
 
     def training_step(self, batch, batch_idx):  # pylint: disable=unused-argument
         x, y = batch

--- a/active_learning/sampling/al_sampler.py
+++ b/active_learning/sampling/al_sampler.py
@@ -295,3 +295,46 @@ def entropy_mc(probabilities: torch.Tensor, sample_size: int) -> np.array:
     idxs = idxs.detach().cpu().numpy()
 
     return idxs
+
+
+def mb_outliers_mean(out_layer_1: torch.Tensor, out_layer_2: torch.Tensor, out_layer_3: torch.Tensor, sample_size: int) -> np.array:
+    """Diversity sampling technique from https://towardsdatascience.com/https-towardsdatascience-com-diversity-sampling-cheatsheet-32619693c304"""
+
+    # calculate mean activations for each layer's activations
+    mean_layer_1 = torch.mean(out_layer_1, dim=-1)
+    mean_layer_2 = torch.mean(out_layer_2, dim=-1)
+    mean_layer_3 = torch.mean(out_layer_3, dim=-1)
+
+    # get average scores across layers
+    scores = (mean_layer_1 + mean_layer_2 + mean_layer_3) / 3
+
+    # make sure sample size doesn't exceed scores
+    sample_size = np.min([len(scores), sample_size])
+
+    # pick k examples with lowest activation scores
+    _, idxs = torch.topk(scores, sample_size, largest=False)
+    idxs = idxs.detach().cpu().numpy()
+    
+    return idxs
+
+
+def mb_outliers_max(out_layer_1: torch.Tensor, out_layer_2: torch.Tensor, out_layer_3: torch.Tensor, sample_size: int) -> np.array:
+    """Diversity sampling technique from https://towardsdatascience.com/https-towardsdatascience-com-diversity-sampling-cheatsheet-32619693c304"""
+
+    # calculate max activations for each layer's activations
+    max_layer_1 = torch.max(out_layer_1, dim=-1).values
+    max_layer_2 = torch.max(out_layer_2, dim=-1).values
+    max_layer_3 = torch.max(out_layer_3, dim=-1).values
+
+    # get overall maximum activation value
+    scores = torch.max(torch.max(max_layer_1, max_layer_2), max_layer_3)
+
+    # make sure sample size doesn't exceed scores
+    sample_size = np.min([len(scores), sample_size])
+
+    # pick k examples with lowest activation scores
+    _, idxs = torch.topk(scores, sample_size, largest=False)
+    idxs = idxs.detach().cpu().numpy()
+    
+    return idxs
+


### PR DESCRIPTION
Changes in droughtwatch.py:
- add method to get activation scores instead of predicted probabilities

Changes in base.py:
- add **kwargs to forward method

Changes in resnet_classifier.py:
- split classification head into 3 parts to allow activation extraction
- add path in forward to extract intermediate activations

Changes in al_sampler.py:
- add two model based outlier sampling methods

Changes in run_experiment.py:
- similar to mc sampling, add separate category for model based outlier sampling