### PR TITLE
Additional sampling strategies + training from scratch in each experiment iteration

### DIFF
--- a/active_learning/data/droughtwatch.py
+++ b/active_learning/data/droughtwatch.py
@@ -198,9 +198,6 @@ class DroughtWatch(BaseDataModule):
         x_train_new = x_pool[sample_idxs]
         y_train_new = y_pool[sample_idxs]
 
-        print('x-train_new size',len(x_train_new))
-        print('len of sample ids',len(sample_idxs))
-
         # remove the new examples from the unlabelled pool
         mask = np.ones(x_pool.shape[0], bool)
         mask[sample_idxs] = False
@@ -215,8 +212,8 @@ class DroughtWatch(BaseDataModule):
         self.data_train = BaseDataset(self.x_train, self.y_train, transform=self.transform)
         self.data_test = BaseDataset(self.x_pool, self.y_pool, transform=self.transform) 
         self.data_unlabelled=BaseDataset(self.x_pool, self.y_pool, transform=self.transform)
-        print(' New train set size ',len(self.x_train))
-        print('New unlabelled pool size ',len(self.x_pool))
+        print('New train set size', len(self.x_train))
+        print('New unlabelled pool size', len(self.x_pool))
 
 
     def get_activation_scores(self, model):

--- a/active_learning/data/droughtwatch.py
+++ b/active_learning/data/droughtwatch.py
@@ -20,7 +20,7 @@ import numpy as np
 DEBUG_OUTPUT = True
 IMG_DIM = 65
 NUM_CLASSES = 4
-N_TRAIN = 20000 # approx 25% of available training samples
+N_TRAIN = 10000
 N_VAL = 10778 # full available validation set
 BANDS = ['B1', 'B2', 'B3', 'B4', 'B5', 'B6', 'B7', 'B8', 'B9', 'B10', 'B11']
 BINARY = False

--- a/active_learning/sampling/al_sampler.py
+++ b/active_learning/sampling/al_sampler.py
@@ -1,5 +1,11 @@
+from math import ceil, isnan
+
+import hdbscan
 import numpy as np
+import pandas as pd
 import torch
+
+DEBUG_OUTPUT = True
 
 
 def random(predictions, sample_size):
@@ -427,3 +433,149 @@ def mb_outliers_mean_entropy(out_layer_1: torch.Tensor, out_layer_2: torch.Tenso
     idxs = idxs.detach().cpu().numpy()
     
     return idxs
+
+
+def mb_clustering(out_layer_1: torch.Tensor, out_layer_2: torch.Tensor, out_layer_3: torch.Tensor, sample_size: int) -> np.array:
+    """Active learning sampling technique that translates instances from the pool to features by using an internal layer of the
+    learner model as featurizer, performing HDBSCAN to cluster the instances and then returning a combination of instances spread
+    across all clusters and outliers detected via GLOSH.
+    """
+    
+    HDBSCAN_CLUSTER_OUTLIER_QUANTILE = 0.9
+    HDBSCAN_CLUSTER_OUTLIER_FRACTION = 0.2
+    
+    # model based featurizing
+    features = out_layer_3.cpu().numpy()
+
+    # cluster and calculate glosh outlier scores
+    clusterer, n_clusters = _hdbscan_cluster_instances(features)
+
+    # initialize variables needed below
+    n_features = len(features)
+    instances_per_cluster = int(sample_size / n_clusters)
+    all_selected_idx = np.array([]).astype(int)
+
+    # check whether distribution between clusters can be done even - if not, distribute remaining equally
+    if sample_size % n_clusters != 0:
+        leftover_instances = sample_size - instances_per_cluster * n_clusters
+    else:
+        leftover_instances = 0
+
+    if DEBUG_OUTPUT:
+        print(f"{n_clusters} clusters found, entering loop to pick instances in all of them...")
+
+    # loop over clusters to select instances in all of them
+    for cluster_id in range(n_clusters):
+
+        # distribute remaining instances if needed
+        if leftover_instances > 0:
+            remaining_clusters = n_clusters - cluster_id
+            additional_instances = ceil((leftover_instances / remaining_clusters))
+            instances_in_cluster = instances_per_cluster + additional_instances
+            leftover_instances -= additional_instances
+        else:
+            instances_in_cluster = instances_per_cluster
+
+        n_outliers = int(instances_in_cluster * HDBSCAN_CLUSTER_OUTLIER_FRACTION)
+        n_regular = instances_in_cluster - n_outliers
+
+        # limit pool to current cluster only
+        # NOTE: possible RuntimeWarning because of NaN values (https://github.com/scikit-learn-contrib/hdbscan/issues/374)
+        cluster_idx_all = np.where(clusterer.labels_ == cluster_id)[0]
+        
+        # divide into main points and outliers
+        outlier_threshold = np.quantile(clusterer.outlier_scores_[cluster_idx_all], HDBSCAN_CLUSTER_OUTLIER_QUANTILE)
+        if not (isnan(outlier_threshold) or outlier_threshold == 0):
+            regular_idx_all = np.where(clusterer.outlier_scores_[cluster_idx_all] < outlier_threshold)[0] 
+            outlier_idx_all = np.where(clusterer.outlier_scores_[cluster_idx_all] >= outlier_threshold)[0]
+        
+        # if possible cluster cannot be devided into main points and outliers, just sample randomly
+        else:
+            n_cluster_points = len(cluster_idx_all)
+            outlier_idx_all = np.random.choice(range(n_cluster_points), int(n_cluster_points*HDBSCAN_CLUSTER_OUTLIER_FRACTION), replace=False)
+            regular_idx_all = np.delete(range(n_cluster_points), outlier_idx_all)
+
+        # avoid having a pool that is too small to sample from
+        if len(regular_idx_all) < n_regular:
+            leftover_instances += n_regular - len(regular_idx_all)
+            n_regular = len(regular_idx_all)
+        if len(outlier_idx_all) < n_outliers:
+            leftover_instances += n_outliers - len(outlier_idx_all)
+            n_outliers = len(outlier_idx_all)
+
+        # select both regular and outlier instances for this cluster
+        regular_idx_selected = np.random.choice(len(regular_idx_all), size=n_regular, replace=False)
+        outlier_idx_selected = np.random.choice(len(outlier_idx_all), size=n_outliers, replace=False)
+
+        # calculate all idx that are selected from this cluster
+        if n_outliers > 0:
+            outlier_idx_original = np.array(range(n_features))[cluster_idx_all][outlier_idx_all][
+                outlier_idx_selected
+            ]  # outlier idx of this cluster (idx translated to full pool)
+        else:
+            outlier_idx_original = np.array([]).astype(int)
+
+        if n_regular > 0:
+            regular_idx_original = np.array(range(n_features))[cluster_idx_all][regular_idx_all][
+                regular_idx_selected
+            ]  # regular idx of this cluster (idx translated to full pool)
+        else:
+            regular_idx_original = np.array([]).astype(int)
+
+        cluster_idx_selected = np.concatenate([outlier_idx_original, regular_idx_original])
+
+        all_selected_idx = np.concatenate([all_selected_idx, cluster_idx_selected])
+
+        if DEBUG_OUTPUT:
+            print(f"Instance selection on cluster no. {cluster_id} done.")
+
+    if len(all_selected_idx) < sample_size:
+        print(f"CAUTION: cluster_outlier_combined algorithm was not able to build a set of {sample_size} instances as requested because HDBSCAN clusters did not contain enough points.")
+        print(f"Selecting {sample_size-len(all_selected_idx)} random instances additionally.")
+
+        remaining_idx = np.delete(range(len(clusterer.labels_)), all_selected_idx)
+        all_selected_idx = np.concatenate([all_selected_idx, np.random.choice(remaining_idx, sample_size-len(all_selected_idx), replace=False)])
+
+    return all_selected_idx
+
+
+def mb_outliers_glosh(out_layer_1: torch.Tensor, out_layer_2: torch.Tensor, out_layer_3: torch.Tensor, sample_size: int) -> np.array:
+    """Active learning sampling technique that translates instances from the pool to features by using an internal layer of the
+    model as featurizer, performing HDBSCAN to cluster the instances and then returning the outliers based on their GLOSH score.
+    """
+
+    # model based featurizing
+    features = out_layer_3.cpu().numpy()
+
+    # cluster and calculate glosh outlier scores
+    clusterer, n_clusters = _hdbscan_cluster_instances(features)
+
+    if DEBUG_OUTPUT:
+        print(f"{n_clusters} clusters found, returning outliers based on max. GLOSH score")
+
+    # select indices with highest outlier scores and return them
+    # NOTE: prints a RuntimeWarning sometimes because of NaN values (https://github.com/scikit-learn-contrib/hdbscan/issues/374)
+    idx = np.argsort(-clusterer.outlier_scores_)[:sample_size] 
+    return idx
+
+
+def _hdbscan_cluster_instances(features):
+
+    HDBSCAN_MIN_CLUSTER_SIZE = 100
+
+    if DEBUG_OUTPUT:
+        print(f"Performing HDBSCAN clustering for pool with shape {features.shape}...")
+
+    # perform clustering
+    n_clusters = -1
+    while n_clusters < 1:
+        clusterer = hdbscan.HDBSCAN(min_cluster_size=HDBSCAN_MIN_CLUSTER_SIZE, min_samples=1).fit(features)
+        n_clusters = clusterer.labels_.max() + 1
+        if n_clusters < 1:
+            if DEBUG_OUTPUT:
+                print(
+                    f"HDBSCAN was not able to find any clusters, halving min. cluster size from {min_cluster_size} to {int(min_cluster_size/2)}"
+                )
+            min_cluster_size = int(min_cluster_size / 2)
+
+    return clusterer, n_clusters

--- a/active_learning/sampling/al_sampler.py
+++ b/active_learning/sampling/al_sampler.py
@@ -526,8 +526,6 @@ def mb_clustering(out_layer_1: torch.Tensor, out_layer_2: torch.Tensor, out_laye
 
         all_selected_idx = np.concatenate([all_selected_idx, cluster_idx_selected])
 
-        if DEBUG_OUTPUT:
-            print(f"Instance selection on cluster no. {cluster_id} done.")
 
     if len(all_selected_idx) < sample_size:
         print(f"CAUTION: cluster_outlier_combined algorithm was not able to build a set of {sample_size} instances as requested because HDBSCAN clusters did not contain enough points.")

--- a/active_learning/sampling/modal_extensions.py
+++ b/active_learning/sampling/modal_extensions.py
@@ -237,8 +237,6 @@ def _featurize_instances(learner, X):
 
         if DEBUG_OUTPUT:
             i += 1
-            if i > 2:
-                break
             if i > ten_percent:
                 print(f"{percentage_output}% of samples in pool featurized")
                 percentage_output += 10

--- a/notebooks/clone_repo_and_train.ipynb
+++ b/notebooks/clone_repo_and_train.ipynb
@@ -32,7 +32,7 @@
         "id": "32Et0yLIrErp"
       },
       "source": [
-        "!git clone --single-branch --branch pytorch_lab_structure https://YOUR_USER_NAME:YOUR_PW_OR_PAT@github.com/matthiaspfenninger/fsdl-active-learning.git # add your own username and pw/pat here"
+        "!git clone https://github.com/ravindrabharathi/fsdl-active-learning2"
       ],
       "execution_count": null,
       "outputs": []
@@ -43,7 +43,7 @@
         "id": "PVuDwtl8t_Ew"
       },
       "source": [
-        "%cd fsdl-active-learning"
+        "%cd fsdl-active-learning2"
       ],
       "execution_count": null,
       "outputs": []
@@ -58,7 +58,7 @@
         "\n",
         "#from google.colab import drive\n",
         "#drive.mount('/content/drive', force_remount=True)\n",
-        "#%cd /content/drive/MyDrive/fsdl-active-learning"
+        "#%cd /content/drive/MyDrive/fsdl-active-learning2"
       ],
       "execution_count": null,
       "outputs": []
@@ -69,8 +69,8 @@
         "id": "1bX8zIz-i2pJ"
       },
       "source": [
-        "!pip3 install boltons wandb pytorch_lightning==1.1.4 pip install torch==1.7.1+cu110 torchvision==0.8.2+cu110 torchaudio==0.7.2 torchtext==0.8.1 -f https://download.pytorch.org/whl/torch_stable.html # general lab / pytorch installs\n",
-        "!pip3 install modAL tensorflow # active learning project\n",
+        "!pip3 install boltons wandb pytorch_lightning==1.2.8 pip install torch==1.7.1+cu110 torchvision==0.8.2+cu110 torchaudio==0.7.2 torchtext==0.8.1 -f https://download.pytorch.org/whl/torch_stable.html # general lab / pytorch installs\n",
+        "!pip3 install modAL tensorflow skorch hdbscan # active learning project\n",
         "\n",
         "%env PYTHONPATH=.:$PYTHONPATH"
       ],
@@ -83,7 +83,8 @@
         "id": "sr_-Brzm1afQ"
       },
       "source": [
-        "!wandb init # initialize w&b"
+        "!wandb login your_personal_wb_key # enter personal w&b key here\n",
+        "!wandb init --project fdsl-active-learning --entity fsdl_active_learners"
       ],
       "execution_count": null,
       "outputs": []
@@ -94,24 +95,7 @@
         "id": "mw7Tcp8Qiw9h"
       },
       "source": [
-        "!python training/run_experiment.py --wandb --gpus=1 --max_epochs=1 --num_workers=4 --data_class=DroughtWatch --model_class=ResnetClassifier --batch_size=32"
-      ],
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "p6qMcsQ_DDGJ"
-      },
-      "source": [
-        "# peeking into preprocessed data can be done as following\n",
-        "import h5py\n",
-        "f = h5py.File(\"data/processed/droughtwatch/trainval.h5\", \"r\")\n",
-        "print(f[\"x_train\"][0:1])\n",
-        "print(f[\"y_train\"][0:1])\n",
-        "print(f[\"x_val\"])\n",
-        "print(f[\"y_val\"])"
+        "!python training/run_experiment.py --sampling_method=mb_clustering --data_class=DroughtWatch --model_class=ResnetClassifier --batch_size=64 --n_train_images=10000 --n_validation_images=10778 --pretrained=True --num_workers=4 --dropout=True --gpus=1 --max_epochs=20"
       ],
       "execution_count": null,
       "outputs": []
@@ -121,9 +105,7 @@
       "metadata": {
         "id": "N_OrR44A4gax"
       },
-      "source": [
-        ""
-      ],
+      "source": [],
       "execution_count": null,
       "outputs": []
     }

--- a/training/run_experiment.py
+++ b/training/run_experiment.py
@@ -14,9 +14,11 @@ np.random.seed(42)
 torch.manual_seed(42)
 
 DEBUG_OUTPUT = True
-MC_SAMPLING_METHODS = ["bald", "max_entropy", "least_confidence_mc", "margin_mc", "ratio_mc", "entropy_mc"]
-MB_SAMPLING_METHODS = ["mb_outliers_mean", "mb_outliers_max", "mb_outliers_mean_least_confidence", "mb_outliers_mean_entropy"]
 MC_ITERATIONS = 10
+
+BASIC_SAMPLING_METHODS = ["random", "least_confidence", "margin", "ratio", "entropy", "least_confidence_pt", "margin_pt", "ratio_pt", "entropy_pt"]
+MC_SAMPLING_METHODS = ["bald", "max_entropy", "least_confidence_mc", "margin_mc", "ratio_mc", "entropy_mc"]
+MB_SAMPLING_METHODS = ["mb_outliers_mean", "mb_outliers_max", "mb_outliers_mean_least_confidence", "mb_outliers_mean_entropy", "mb_outliers_glosh", "mb_clustering"]
 
 
 def _import_class(module_and_class_name: str) -> type:
@@ -41,7 +43,6 @@ def _setup_parser():
     parser.add_argument("--data_class", type=str, default="DroughtWatch")
     parser.add_argument("--model_class", type=str, default="ResnetClassifier")
     parser.add_argument("--load_checkpoint", type=str, default=None)
-    parser.add_argument("--sampling_method", type=str, default="random")
 
     # Get the data and model classes, so that we can add their specific arguments
     temp_args, _ = parser.parse_known_args()
@@ -57,6 +58,11 @@ def _setup_parser():
 
     lit_model_group = parser.add_argument_group("LitModel Args")
     lit_models.BaseLitModel.add_to_argparse(lit_model_group)
+
+    # Active learning specific arguments
+    parser.add_argument("--sampling_method", type=str, choices=BASIC_SAMPLING_METHODS+MC_SAMPLING_METHODS+MB_SAMPLING_METHODS, default="random", help="Active learning sampling strategy")
+    parser.add_argument("--al_iter", type=int, default=-1, help="No. of active learning iterations (-1 to iterate until pool is exhausted)")
+    parser.add_argument("--al_samples_per_iter", type=int, default=2000, help="No. of samples to query per active learning iteration")
 
     parser.add_argument("--help", "-h", action="help")
     return parser
@@ -79,7 +85,7 @@ def main():
     data = data_class(args)
     model = model_class(data_config=data.config(), args=args)
 
-    sampling_method = args.sampling_method
+    sampling_method = args.al_sampling_method
     sampling_class = _import_class(f"active_learning.sampling.al_sampler.{sampling_method}")
 
     lit_model_class = lit_models.BaseLitModel
@@ -90,8 +96,9 @@ def main():
         lit_model = lit_model_class(args=args, model=model)
 
     # --wandb args parameter ignored for now, always using wandb
+    # specify project & entity outside of code, example: wandb init --project fdsl-active-learning --entity fsdl_active_learners
     project_name = "fsdl-active-learning_" + sampling_method
-    logger = pl.loggers.WandbLogger(name=project_name, project="fsdl-active-learning", job_type="train")
+    logger = pl.loggers.WandbLogger(name=project_name, job_type="train") 
     logger.watch(model)
     logger.log_hyperparams(vars(args))
 
@@ -107,15 +114,17 @@ def main():
 
     unlabelled_data_size = data.get_ds_length(ds_name="unlabelled")
     trainer.tune(lit_model, datamodule=data)  # If passing --auto_lr_find, this will set learning rate
+
+    al_iterations = 0
     
-    while unlabelled_data_size > 1000:
+    while unlabelled_data_size > 0 and (args.al_n_iter < 0 or al_iterations < args.al_n_iter):
 
         # fit model on current data
         trainer.fit(lit_model, datamodule=data)
 
-        # if pool is large enough, take 2000 new samples - otherwise take all remaining ones
-        if unlabelled_data_size > 2000:
-            sample_size = 2000
+        # if pool is large enough, take 'al_n_samples_per_iter' new samples - otherwise take all remaining ones
+        if unlabelled_data_size > args.al_n_samples_per_iter:
+            sample_size = args.al_n_samples_per_iter
         else:
             sample_size = unlabelled_data_size
 
@@ -156,6 +165,8 @@ def main():
         # adjust training set and unlabelled pool based on new queried indices
         data.expand_training_set(new_indices)
         unlabelled_data_size = data.get_ds_length(ds_name="unlabelled")
+
+        al_iterations += 1
 
     wandb.finish()
 


### PR DESCRIPTION
## Main

New sampling methods:
- `mb_outliers_glosh`: Diversity sampling, via outlier scores (GLOSH) calculated from model based extracted features
- `mb_clustering`: Diversity sampling, via clustering (HDBSCAN) and outlier (GLOSH) combined, calculated from model based extracted features

Experiment routine fixes / improvements:
- Train from scratch instead of continuing training by properly re-initializing model, callbacks and trainer. Additional `al_continue_training` parameter to activate 'old' behaviour


## Others

- Experiment routine: More args parametrizing for active learning iteration size etc.
- Default value change: N_TRAIN from 20k reduced to 10k
- Update notebook with current call and updated pytorch_lightning version
- Remove accidental modAL experiment routine debug `break` statement
- Remove duplicate/unnecessary output statements