### PR TITLE
active transfer learning, DAL, f1 score

### DIFF
--- a/active_learning/lit_models/base.py
+++ b/active_learning/lit_models/base.py
@@ -16,6 +16,8 @@ class MaxAccuracyLogger(pl.callbacks.Callback):
 
     train_acc_max = 0
     val_acc_max = 0
+    train_f1_max = 0
+    val_f1_max = 0
 
     def on_validation_epoch_end(self, trainer, pl_module):
         metrics = trainer.callback_metrics
@@ -24,15 +26,35 @@ class MaxAccuracyLogger(pl.callbacks.Callback):
         if "train_acc" in metrics:
             self.train_acc_max = max(self.train_acc_max, metrics["train_acc"].item())
             self.val_acc_max = max(self.val_acc_max, metrics["val_acc"].item())
+            self.train_f1_max = max(self.train_f1_max, metrics["train_f1"].item())
+            self.val_f1_max = max(self.val_f1_max, metrics["val_f1"].item())
             train_size = trainer.datamodule.get_ds_length('train')
 
             pl_module.log("train_acc_max", self.train_acc_max)
             pl_module.log("val_acc_max", self.val_acc_max)
+            pl_module.log("train_f1_max", self.train_f1_max)
+            pl_module.log("val_f1_max", self.val_f1_max)
             pl_module.log("train_size", train_size)
 
 
 class Accuracy(pl.metrics.Accuracy):
     """Accuracy Metric with a hack."""
+
+    def update(self, preds: torch.Tensor, target: torch.Tensor) -> None:
+        """
+        Metrics in Pytorch-lightning 1.2+ versions expect preds to be between 0 and 1 else fails with the ValueError:
+        "The `preds` should be probabilities, but values were detected outside of [0,1] range."
+        This is being tracked as a bug in https://github.com/PyTorchLightning/metrics/issues/60.
+        This method just hacks around it by normalizing preds before passing it in.
+        Normalized preds are not necessary for accuracy computation as we just care about argmax().
+        """
+        if preds.min() < 0 or preds.max() > 1:
+            preds = torch.nn.functional.softmax(preds, dim=-1)
+        super().update(preds=preds, target=target)
+
+
+class F1_Score(pl.metrics.F1):
+    """F1-Score Metric with a hack."""
 
     def update(self, preds: torch.Tensor, target: torch.Tensor) -> None:
         """
@@ -71,12 +93,25 @@ class BaseLitModel(pl.LightningModule):  # pylint: disable=too-many-ancestors
 
         self.one_cycle_max_lr = self.args.get("one_cycle_max_lr", None)
         self.one_cycle_total_steps = self.args.get("one_cycle_total_steps", ONE_CYCLE_TOTAL_STEPS)
+        
+        binary = self.args.get("binary", False)
+        if binary:
+            num_classes = 2
+        else:
+            num_classes = 4
 
         self.train_acc = Accuracy()
         self.val_acc = Accuracy()
         self.test_acc = Accuracy()
-        self.predictions=np.array([])
-        self.train_size=0
+
+        self.train_f1 = F1_Score(num_classes=num_classes)
+        self.val_f1 = F1_Score(num_classes=num_classes)
+        self.test_f1 = F1_Score(num_classes=num_classes)
+
+        self.predictions = np.array([])
+        self.train_size = 0
+        self.val_predictions = torch.Tensor()
+        self.logging = True
 
     @staticmethod
     def add_to_argparse(parser):
@@ -104,10 +139,15 @@ class BaseLitModel(pl.LightningModule):  # pylint: disable=too-many-ancestors
         
         logits = self(x)
         loss = self.loss_fn(logits, y)
-        self.log("train_loss", loss,on_step=False, on_epoch=True,prog_bar=False)
         self.train_acc(logits, y)
-        self.log("train_acc", self.train_acc, on_step=False, on_epoch=True, prog_bar=False)
-        self.log("train_size", self.trainer.datamodule.get_ds_length('train'), on_step=False, on_epoch=True, prog_bar=False)
+        self.train_f1(logits, y)
+
+        if self.logging:
+            self.log("train_loss", loss,on_step=False, on_epoch=True,prog_bar=False)
+            self.log("train_acc", self.train_acc, on_step=False, on_epoch=True, prog_bar=False)
+            self.log("train_f1", self.train_f1, on_step=False, on_epoch=True, prog_bar=False)
+            self.log("train_size", self.trainer.datamodule.get_ds_length('train'), on_step=False, on_epoch=True, prog_bar=False)
+        
         return loss
 
     def validation_step(self, batch, batch_idx):  # pylint: disable=unused-argument
@@ -115,10 +155,20 @@ class BaseLitModel(pl.LightningModule):  # pylint: disable=too-many-ancestors
         x, y = batch
         logits = self(x)
         loss = self.loss_fn(logits, y)
-        self.log("val_loss", loss, on_step=False, on_epoch=True,prog_bar=False)
         self.val_acc(logits, y)
-        self.log("val_acc", self.val_acc, on_step=False, on_epoch=True, prog_bar=False)
-        self.log("train_size", self.trainer.datamodule.get_ds_length('train'), on_step=False, on_epoch=True, prog_bar=False)
+        self.val_f1(logits, y)
+
+        if self.logging:
+            self.log("val_loss", loss, on_step=False, on_epoch=True,prog_bar=False)
+            self.log("val_acc", self.val_acc, on_step=False, on_epoch=True, prog_bar=False)
+            self.log("val_f1", self.val_f1, on_step=False, on_epoch=True, prog_bar=False)
+            self.log("train_size", self.trainer.datamodule.get_ds_length('train'), on_step=False, on_epoch=True, prog_bar=False)
+
+        # store validation predictions
+        if len(self.val_predictions) in [0, 10778]:
+            self.val_predictions = logits.detach()
+        else:
+            self.val_predictions = torch.cat([self.val_predictions, logits.detach()])
 
     def reset_predictions(self):
         print('\nResetting Predictions\n')
@@ -128,15 +178,17 @@ class BaseLitModel(pl.LightningModule):  # pylint: disable=too-many-ancestors
     def test_step(self, batch, batch_idx):  # pylint: disable=unused-argument
         x, y = batch
         logits = self(x)
+        self.test_acc(logits, y)
+        self.test_f1(logits, y)
         
         preds = torch.nn.functional.softmax(logits, dim=-1)
         
         if self.predictions.shape[0]==0:
             self.predictions=preds.cpu().detach().numpy()
         else:  
-              
             self.predictions=np.vstack([self.predictions,preds.cpu().detach().numpy()])
-
-        self.test_acc(logits, y)
-        self.log("test_acc", self.test_acc, on_step=False, on_epoch=True, prog_bar=False)
-        self.log("train_size", self.trainer.datamodule.get_ds_length('train'), on_step=False, on_epoch=True, prog_bar=False)
+        
+        if self.logging:
+            self.log("test_acc", self.test_acc, on_step=False, on_epoch=True, prog_bar=False)
+            self.log("test_f1", self.test_f1, on_step=False, on_epoch=True, prog_bar=False)
+            self.log("train_size", self.trainer.datamodule.get_ds_length('train'), on_step=False, on_epoch=True, prog_bar=False)

--- a/training/run_experiment.py
+++ b/training/run_experiment.py
@@ -4,10 +4,13 @@ import importlib
 
 import numpy as np
 import torch
+import torch.nn as nn
 import pytorch_lightning as pl
 import wandb
+from sklearn.model_selection import train_test_split
 
 from active_learning import lit_models
+from active_learning.data.util import BaseDataset
 from active_learning.lit_models.base import MaxAccuracyLogger
 
 # In order to ensure reproducible experiments, we must set random seeds.
@@ -20,6 +23,7 @@ MC_ITERATIONS = 10
 BASIC_SAMPLING_METHODS = ["random", "least_confidence", "margin", "ratio", "entropy", "least_confidence_pt", "margin_pt", "ratio_pt", "entropy_pt"]
 MC_SAMPLING_METHODS = ["bald", "max_entropy", "least_confidence_mc", "margin_mc", "ratio_mc", "entropy_mc"]
 MB_SAMPLING_METHODS = ["mb_outliers_mean", "mb_outliers_max", "mb_outliers_mean_least_confidence", "mb_outliers_mean_entropy", "mb_outliers_glosh", "mb_clustering"]
+ATL_SAMPLING_METHODS = ["active_transfer_learning", "DAL"]
 
 
 def _import_class(module_and_class_name: str) -> type:
@@ -61,7 +65,7 @@ def _setup_parser():
     lit_models.BaseLitModel.add_to_argparse(lit_model_group)
 
     # Active learning specific arguments
-    parser.add_argument("--sampling_method", type=str, choices=BASIC_SAMPLING_METHODS+MC_SAMPLING_METHODS+MB_SAMPLING_METHODS, default="random", help="Active learning sampling strategy")
+    parser.add_argument("--sampling_method", type=str, choices=BASIC_SAMPLING_METHODS+MC_SAMPLING_METHODS+MB_SAMPLING_METHODS+ATL_SAMPLING_METHODS, default="random", help="Active learning sampling strategy")
     parser.add_argument("--al_iter", type=int, default=-1, help="No. of active learning iterations (-1 to iterate until pool is exhausted)")
     parser.add_argument("--al_samples_per_iter", type=int, default=2000, help="No. of samples to query per active learning iteration")
     parser.add_argument("--al_continue_training", action='store_true', help="Whether to continue training after sampling from pool (instead of training from scratch each time")
@@ -96,7 +100,82 @@ def _initialize_trainer(model_class, lit_model_class, data, args, logger, al_ite
     trainer = pl.Trainer.from_argparse_args(args, callbacks=callbacks, logger=logger, weights_save_path="training/logs")
     trainer.tune(lit_model, datamodule=data)  # If passing --auto_lr_find, this will set learning rate
 
+    # for active transfer learning methods disactivate sanity check
+    if args.sampling_method in ATL_SAMPLING_METHODS:
+        trainer.num_sanity_val_steps = 0
+
     return trainer, lit_model
+
+
+def _prepare_dataloaders(new_data, new_labels, data, args, val_split=0.2):
+
+    # shuffle dataset
+    randomize = np.arange(len(new_data))
+    np.random.shuffle(randomize)
+    new_data = new_data[randomize]
+    new_labels = new_labels[randomize]
+
+    # create training and validation sets
+    X_train, X_test, y_train, y_test = train_test_split(new_data, new_labels, test_size=val_split, random_state=42)
+
+    # create datasets
+    new_train_ds = BaseDataset(X_train, y_train, transform=data.transform)
+    new_val_ds = BaseDataset(X_test, y_test, transform=data.transform)
+
+    # create dataloaders
+    new_train_dataloader = torch.utils.data.DataLoader(new_train_ds, shuffle=True, batch_size=args.batch_size, num_workers=args.num_workers)
+    new_val_dataloader = torch.utils.data.DataLoader(new_val_ds, shuffle=False, batch_size=args.batch_size, num_workers=args.num_workers)
+
+    return new_train_dataloader, new_val_dataloader
+
+
+def _finetune_and_sample(lit_model, data, new_train_dataloader, new_val_dataloader, sample_size, args):
+
+    print(f"\nStarting fine-tuning for {args.sampling_method}")
+
+    # create new classification head
+    new_head_part_2 = nn.Sequential(
+        nn.BatchNorm1d(lit_model.model.head_part_1[3].out_features), # adding batchnorm
+        nn.ReLU(), # additional nonlinearity
+        nn.Dropout(lit_model.model.head_part_1[2].p), # additional dropout layer
+        nn.Linear(lit_model.model.head_part_1[3].out_features, 2) # same fc layer as we had before
+    )
+
+    # replace lit model head
+    lit_model.model.head_part_2 = new_head_part_2
+
+    # freeze Resnet backbone
+    for p in lit_model.model.resnet.parameters():
+        p.requires_grad = False
+
+    # turn off logging
+    lit_model.logging = False
+
+    # initialize trainer
+    early_stopping_callback = pl.callbacks.EarlyStopping(monitor="val_loss", mode="min", patience=2)
+    trainer = pl.Trainer(gpus=args.gpus, progress_bar_refresh_rate=30, max_epochs=10, num_sanity_val_steps=0)
+    trainer.tune(lit_model, train_dataloader=new_train_dataloader, val_dataloaders=new_val_dataloader)
+
+    # fit trainer on new data
+    trainer.fit(lit_model, train_dataloader=new_train_dataloader, val_dataloaders=new_val_dataloader)
+
+    # run inference on unlabelled pool
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    pool_dl = data.unlabelled_dataloader()
+    all_preds = torch.Tensor().to(device)
+    lit_model.to(device)
+    lit_model.eval()
+    with torch.no_grad():
+        for x,_ in pool_dl:
+            logits = lit_model(x.to(device))
+            preds = nn.functional.softmax(logits, dim=-1)
+            all_preds = torch.cat([all_preds, preds])
+    
+    # sample indices from prediction scores
+    _, idxs = torch.topk(all_preds[:,0], sample_size, largest=True)
+    idxs = idxs.detach().cpu().numpy()
+
+    return idxs
 
 
 def main():
@@ -116,13 +195,24 @@ def main():
     data = data_class(args)
 
     sampling_method = args.sampling_method
-    sampling_class = _import_class(f"active_learning.sampling.al_sampler.{sampling_method}")
+    if not sampling_method in ATL_SAMPLING_METHODS:
+        sampling_class = _import_class(f"active_learning.sampling.al_sampler.{sampling_method}")
 
     lit_model_class = lit_models.BaseLitModel
 
+    # get info about scenario for logging
+    if args.binary:
+        class_scenario = "_binary"
+    else:
+        class_scenario = "_multi-class"
+    if args.rgb:
+        channel_scenario = "_rgb"
+    else:
+        channel_scenario = "_all-channels"
+
     # --wandb args parameter ignored for now, always using wandb
     # specify project & entity outside of code, example: wandb init --project fdsl-active-learning --entity fsdl_active_learners
-    project_name = "fsdl-active-learning_" + sampling_method
+    project_name = "fsdl-active-learning_" + sampling_method + class_scenario + channel_scenario
     logger = pl.loggers.WandbLogger(name=project_name, job_type="train") 
     logger.log_hyperparams(vars(args))
 
@@ -141,8 +231,10 @@ def main():
         # log best accuracies of this iteration to wandb
         wandb.log({
             "train_size": data.get_ds_length(ds_name="train"),
-            "train_acc_best": trainer.callback_metrics["train_acc_max"],
-            "val_acc_best": trainer.callback_metrics["val_acc_max"],
+            "train_acc_best": trainer.callback_metrics.get("train_acc_max"),
+            "val_acc_best": trainer.callback_metrics.get("val_acc_max"),
+            "train_f1_best": trainer.callback_metrics.get("train_f1_max"),
+            "val_f1_best": trainer.callback_metrics.get("val_f1_max"),
         })
 
         # if pool is large enough, take 'al_samples_per_iter' new samples - otherwise take all remaining ones
@@ -167,6 +259,51 @@ def main():
             out_layer_0, out_layer_1, out_layer_2 = data.get_activation_scores(lit_model)
 
             new_indices = sampling_class(out_layer_0, out_layer_1, out_layer_2, sample_size)
+
+        elif sampling_method == "active_transfer_learning":
+
+            # get validation set predictions
+            val_preds = torch.max(lit_model.val_predictions, dim=-1)[1]
+            val_preds = val_preds.cpu().numpy()
+
+            # new labels will be correct/incorrect
+            new_labels = (val_preds == data.data_val.targets)
+            new_labels = new_labels.astype(int)
+
+            # get dataloaders
+            new_train_dataloader, new_val_dataloader = _prepare_dataloaders(data.data_val.data, new_labels, data, args)
+
+            # run fine-tuning and sampling
+            new_indices = _finetune_and_sample(lit_model, data, new_train_dataloader, new_val_dataloader, sample_size, args)
+
+        elif sampling_method == "DAL":
+
+            # create equal sized sample from training set and unlabelled pool
+            min_size = np.min([len(data.data_train.data), len(data.data_unlabelled.data)])
+            if len(data.data_train.data) > len(data.data_unlabelled.data):
+                subsample = np.random.choice(len(data.data_train.data), min_size, replace=False)
+                new_train_data = data.data_train.data[subsample]
+                new_pool_data = data.data_unlabelled.data
+            elif len(data.data_train.data) < len(data.data_unlabelled.data):
+                subsample = np.random.choice(len(data.data_unlabelled.data), min_size, replace=False)
+                new_train_data = data.data_train.data
+                new_pool_data = data.data_unlabelled.data[subsample]
+            else:
+                new_train_data = data.data_train.data
+                new_pool_data = data.data_unlabelled.data
+            assert len(new_train_data) == len(new_pool_data)
+
+            # create dataset of training and unlabelled pool
+            # 1 = labelled, 2 = unlabelled
+            new_data = np.concatenate([new_train_data, new_pool_data])
+            new_labels = [1]*len(new_train_data) + [0]*len(new_pool_data)
+            new_labels = np.array(new_labels)
+
+            # get dataloaders
+            new_train_dataloader, new_val_dataloader = _prepare_dataloaders(new_data, new_labels, data, args)
+
+            # run fine-tuning and sampling
+            new_indices = _finetune_and_sample(lit_model, data, new_train_dataloader, new_val_dataloader, sample_size, args)
 
         else:
 


### PR DESCRIPTION
base.py:
- added micro f1 score
- added option to turn off logging (self.logging)

run_experiment.py:
- added logging of f1 score
- added two transfer-learning-based sampling strategies: active transfer learning (for uncertainty sampling), discriminative active learning (DAL)
- added helper functions _prepare_dataloaders and _finetune_sample

Note: sampling methods are directly implemented in run_experiment.py instead of al_sampler.py due to reliance on trainer, lit model, etc.