### PR TITLE
Mnist

### DIFF
--- a/active_learning/data/__init__.py
+++ b/active_learning/data/__init__.py
@@ -1,30 +1,4 @@
 from .util import BaseDataset
 from .base_data_module import BaseDataModule
-'''
-from .mnist import MNIST
-
-# Hide lines below until Lab 2
-from .emnist import EMNIST
-from .emnist_lines import EMNISTLines
-
-# Hide lines above until Lab 2
-
-# Hide lines below until Lab 5
-from .emnist_lines2 import EMNISTLines2
-from .iam_lines import IAMLines
-
-# Hide lines above until Lab 5
-
-# Hide lines below until Lab 7
-from .iam_paragraphs import IAMParagraphs
-from .iam_original_and_synthetic_paragraphs import IAMOriginalAndSyntheticParagraphs
-
-# Hide lines above until Lab 7
-
-# Hide lines below until Lab 8
-from .fake_images import FakeImageData
-
-# Hide lines above until Lab 8
-'''
-# added by active-learning-project
 from .droughtwatch import DroughtWatch
+from .mnist import MNIST

--- a/active_learning/data/droughtwatch.py
+++ b/active_learning/data/droughtwatch.py
@@ -171,6 +171,7 @@ class DroughtWatch(BaseDataModule):
         )
         return basic + data
 
+'''
     def get_ds_length(self,ds_name='unlabelled'):
         
         if ds_name=='unlabelled':
@@ -306,6 +307,12 @@ class DroughtWatch(BaseDataModule):
         
         return all_outputs
 
+       
+def _enable_dropout(model):
+    for each_module in model.modules():
+        if each_module.__class__.__name__.startswith('Dropout'):
+            each_module.train()
+'''
 
 def _check_disk_dataset_availability(self):
 
@@ -447,11 +454,6 @@ def _process_raw_dataset(self, filename: str, dirname: Path):
     print("Cleaning up...")
     shutil.rmtree("droughtwatch_data")
     os.chdir(curdir)
-          
-def _enable_dropout(model):
-    for each_module in model.modules():
-        if each_module.__class__.__name__.startswith('Dropout'):
-            each_module.train()
 
 
 if __name__ == "__main__":

--- a/active_learning/data/droughtwatch.py
+++ b/active_learning/data/droughtwatch.py
@@ -141,9 +141,9 @@ class DroughtWatch(BaseDataModule):
         self.data_test = BaseDataset(self.x_pool, self.y_pool, transform=self.transform) 
         self.data_unlabelled = BaseDataset(self.x_pool, self.y_pool, transform=self.transform)
 
-        print(f"\nInitial training set size: {len(self.data_train)}")
-        print(f"Initial unlabelled pool size: {len(self.data_unlabelled)}")
-        print(f"Validation set size: {len(self.data_val)}\n")
+        print(f"\nInitial training set size: {len(self.data_train)} - shape: {self.data_train.data.shape}")
+        print(f"Initial unlabelled pool size: {len(self.data_unlabelled)} - shape: {self.data_unlabelled.data.shape}")
+        print(f"Validation set size: {len(self.data_val)} - shape: {self.data_val.data.shape}\n")
         
 
 
@@ -171,148 +171,6 @@ class DroughtWatch(BaseDataModule):
         )
         return basic + data
 
-'''
-    def get_ds_length(self,ds_name='unlabelled'):
-        
-        if ds_name=='unlabelled':
-            return len(self.data_unlabelled.data)
-        elif ds_name=='train':
-            return len(self.data_train.data)
-        elif ds_name=='test' :
-            return len(self.data_test.data)
-        elif ds_name=='val' :
-            return len(self.data_val.data)
-        else:
-            raise NameError('Unknown Dataset Name '+ds_name) 
-           
-
-    def expand_training_set(self, sample_idxs):
-
-        #get x_train, y_train
-        x_train=self.data_train.data
-        y_train=self.data_train.targets
-        #get unlabelled set
-        x_pool=self.data_unlabelled.data
-        y_pool=self.data_unlabelled.targets
-
-        # get new training examples
-        x_train_new = x_pool[sample_idxs]
-        y_train_new = y_pool[sample_idxs]
-
-        # remove the new examples from the unlabelled pool
-        mask = np.ones(x_pool.shape[0], bool)
-        mask[sample_idxs] = False
-        self.x_pool = x_pool[mask]
-        self.y_pool = y_pool[mask]
-
-
-        # add new examples to training set
-        self.x_train = np.concatenate([x_train, x_train_new])
-        self.y_train = np.concatenate([y_train, y_train_new])
-
-        self.data_train = BaseDataset(self.x_train, self.y_train, transform=self.transform)
-        self.data_test = BaseDataset(self.x_pool, self.y_pool, transform=self.transform) 
-        self.data_unlabelled=BaseDataset(self.x_pool, self.y_pool, transform=self.transform)
-        print('New train set size', len(self.x_train))
-        print('New unlabelled pool size', len(self.x_pool))
-
-
-    def get_activation_scores(self, model):
-
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        
-        # for some reason, lightning module is not yet on cuda, even if it was initialized that way --> transfer it
-        model = model.to(device)
-
-        # pytorch dataloader for batch-wise processing
-        all_samples = self.unlabelled_dataloader()
-
-        # initialize pytorch tensors to store activation scores
-        out_layer_1 = torch.Tensor().to(device)
-        out_layer_2 = torch.Tensor().to(device)
-        out_layer_3 = torch.Tensor().to(device)
-
-        model.eval()
-        with torch.no_grad():
-
-            # loop through batches in unlabelled pool
-            for batch_features, _ in all_samples:
-                
-                # move features to device
-                batch_features = batch_features.to(device)
-
-                # extract intermediate and final activations
-                out1, out2, out3 = model(batch_features, extract_intermediate_activations=True)
-
-                # store batch results
-                out_layer_1 = torch.cat([out_layer_1, out1])
-                out_layer_2 = torch.cat([out_layer_2, out2])
-                out_layer_3 = torch.cat([out_layer_3, out3])
-
-        return out_layer_1, out_layer_2, out_layer_3
-
-
-    def get_pool_probabilities(self, model, T=10):
-
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        
-        # for some reason, lightning module is not yet on cuda, even if it was initialized that way --> transfer it
-        model = model.to(device)
-
-        # pytorch dataloader for batch-wise processing
-        all_samples = self.unlabelled_dataloader()
-
-        if DEBUG_OUTPUT:
-            print("Processing pool of instances to generate probabilities")
-            print("(Note: Based on the pool size this takes a while. Will generate debug output every 5%.)\n")
-            five_percent = int(self.get_ds_length(ds_name="unlabelled") / all_samples.batch_size / 20)
-            i = 0
-            percentage_output = 5
-
-        # initialize pytorch tensor to store acquisition scores
-        all_outputs = torch.Tensor().to(device)
-
-        # set model to eval (non-training) modus and enable dropout layers
-        model.eval()
-        _enable_dropout(model)
-
-        if self.reduced_pool:
-            print("NOTE: Reduced pool dev parameter activated, will only process first batch")
-            all_samples = [next(all_samples._get_iterator())]
-
-
-        # process pool of instances batch wise
-        for batch_features, _ in all_samples:
-
-            with torch.no_grad():
-                outputs = torch.stack(
-                    [
-                        torch.softmax( # probabilities from logits
-                            model(batch_features.to(device)), dim=-1) # logits
-                        for t in range(T) # multiple calculations
-                    ]
-                , dim = -1)
-
-            all_outputs = torch.cat([all_outputs, outputs], dim = 0)
-
-            if DEBUG_OUTPUT:
-                i += 1
-                if i > five_percent:
-                    print(f"{percentage_output}% of samples in pool processed")
-                    percentage_output += 5
-                    i = 0
-
-        if DEBUG_OUTPUT:
-            print(f"100% of samples in pool processed\n")
-        
-        return all_outputs
-
-       
-def _enable_dropout(model):
-    for each_module in model.modules():
-        if each_module.__class__.__name__.startswith('Dropout'):
-            each_module.train()
-'''
 
 def _check_disk_dataset_availability(self):
 

--- a/active_learning/data/mnist.py
+++ b/active_learning/data/mnist.py
@@ -1,18 +1,19 @@
 """MNIST DataModule"""
-from active_learning.data.util import BaseDataset, split_dataset
+from torch.utils.data.dataloader import DataLoader
+from torch.utils.data.dataset import random_split
+from active_learning.data.util import BaseDataset
 import argparse
 
+import torch
 from torchvision.datasets import MNIST as TorchMNIST
 from torchvision import transforms
 
 from active_learning.data.base_data_module import BaseDataModule, load_and_print_info
 
-DOWNLOADED_DATA_DIRNAME = BaseDataModule.data_dirname() / "downloaded"
-
 # NOTE: temp fix until https://github.com/pytorch/vision/issues/1938 is resolved
-from six.moves import urllib  # pylint: disable=wrong-import-position, wrong-import-order
+from six.moves import urllib
 
-
+DOWNLOADED_DATA_DIRNAME = BaseDataModule.data_dirname() / "downloaded"
 N_TRAIN = 2000
 N_VAL = 10000
 BINARY = False
@@ -40,18 +41,14 @@ class MNIST(BaseDataModule):
         self.n_validation_images = self.args.get("n_validation_images", N_VAL)
         self.binary = self.args.get("binary", BINARY)
 
-        self.transform = transforms.Compose([
-            transforms.Resize((224, 224)), 
-            transforms.ToTensor(), 
-            transforms.Normalize((0.1307,), (0.3081,))
-            ])
+        self.transform = None
 
-        self.dims = (1, 64, 64) 
+        self.dims = (1, 1, 64, 64) 
         self.output_dims = (1,)
         self.mapping = list(range(10))
 
         self.prepare_data(args)
-        self.setup()
+        self.init_setup(args)
 
     def prepare_data(self, *args, **kwargs) -> None:
         """Download train and test MNIST data from PyTorch canonical source."""
@@ -63,29 +60,53 @@ class MNIST(BaseDataModule):
         TorchMNIST(self.data_dir, train=True, download=True)
         TorchMNIST(self.data_dir, train=False, download=True)
 
-    def setup(self, stage=None) -> None:
+    def init_setup(self, args: argparse.Namespace, stage=None) -> None:
         """Split into train, val, test and pool."""
-        mnist_full = TorchMNIST(self.data_dir, train=True, transform=self.transform) # transform=self.transform
-        mnist_full = BaseDataset(mnist_full.data.float().unsqueeze(0), mnist_full.targets)
 
-        val_fraction = self.n_validation_images/60000
-        pool_fraction = (60000-self.n_validation_images-self.n_train_images)/(60000-self.n_validation_images)
+        # load train set initially to calculate mean/std for normalization
+        mnist = TorchMNIST(self.data_dir, train=True).data.float()
 
-        self.data_val, train_and_pool = split_dataset(mnist_full, val_fraction, seed = 43)
+        # define transformation to normalize data
+        transform = transforms.Compose([
+            transforms.Resize((224, 224)), 
+            transforms.ToTensor(), 
+            transforms.Normalize(mean=mnist.mean()/255, std=mnist.std()/255)
+            ])
+        
+        # load MNIST train dataset with transformation
+        mnist_full = TorchMNIST(self.data_dir, train=True, transform=transform)
 
-        self.data_train, self.data_unlabelled = split_dataset(train_and_pool, pool_fraction, seed = 43)
+        # randomly divide into val / train_pool
+        data_val_subset, train_pool_subset = random_split(mnist_full, [self.n_validation_images, 60000-self.n_validation_images])
 
-        data_test_mnist = TorchMNIST(self.data_dir, train=False, transform=self.transform) # transform=self.transform
+        # convert to DataLoaders and extract data
+        data_val_x, data_val_y = next(iter(DataLoader(mnist_full, sampler=data_val_subset.indices, batch_size=len(data_val_subset.indices))))
+        self.data_val = BaseDataset(data_val_x, data_val_y)
+        train_pool_x, train_pool_y = next(iter(DataLoader(mnist_full, sampler=train_pool_subset.indices, batch_size=len(train_pool_subset.indices))))
 
+        # create dataset from train_pool
+        train_pool = BaseDataset(train_pool_x, train_pool_y)
 
-        #self.data_train = BaseDataModule(data_train_mnist, data_train_mnist.targets)
-        #self.data_val = BaseDataModule(data_val_mnist.data, data_val_mnist.targets)
-        self.data_test = BaseDataset(data_test_mnist.data.float().unsqueeze(0), data_test_mnist.targets)
-        #self.data_unlabelled = BaseDataModule(data_unlabelled_mnist.data, data_unlabelled_mnist.targets)
+        # randomly divide into train / pool
+        data_train_subset, data_pool_subset = random_split(train_pool, [self.n_train_images, 60000-self.n_validation_images-self.n_train_images])
 
-        print(f"\nInitial training set size: {len(self.data_train)}")
-        print(f"Initial unlabelled pool size: {len(self.data_unlabelled)}")
-        print(f"Validation set size: {len(self.data_val)}\n")
+        # convert to DataLoaders and extract data
+        data_train_x, data_train_y = next(iter(DataLoader(train_pool, sampler=data_train_subset.indices, batch_size=len(data_train_subset.indices))))
+        self.data_train = BaseDataset(data_train_x, data_train_y)
+        data_unlabelled_x, data_unlabelled_y = next(iter(DataLoader(train_pool, sampler=data_pool_subset.indices, batch_size=len(data_pool_subset.indices))))
+        self.data_unlabelled = BaseDataset(data_unlabelled_x, data_unlabelled_y)
+
+        # load test dataset
+        self.data_test = TorchMNIST(self.data_dir, train=False, transform=transform)
+
+        print(f"\nInitial training set size: {len(self.data_train)} - shape: {self.data_train.data.shape}")
+        print(f"Initial unlabelled pool size: {len(self.data_unlabelled)} - shape: {self.data_unlabelled.data.shape}")
+        print(f"Validation set size: {len(self.data_val)} - shape: {self.data_val.data.shape}\n")
+
+        assert self.data_train.data.shape[1:] == torch.Size([1, 224, 224]), f"invalid data_train shape: {self.data_train.data.shape[1:]}"
+        assert self.data_val.data.shape[1:] == torch.Size([1, 224, 224]), f"invalid data_val shape: {self.data_val.data.shape[1:]}"
+        assert self.data_unlabelled.data.shape[1:] == torch.Size([1, 224, 224]), f"invalid data_unlabelled shape: {self.data_unlabelled.data.shape[1:]}"
+
 
     def __repr__(self):
         basic = f"MNIST Dataset\nDims: {self.dims}\n"
@@ -95,154 +116,13 @@ class MNIST(BaseDataModule):
         # deepcode ignore unguarded~next~call: call to just initialized train_dataloader always returns data
         x, y = next(iter(self.train_dataloader()))
         data = (
+            f"Train/Val/Pool data shapes: {self.data_train.data.shape}, {self.data_val.data.shape}, {self.data_unlabelled.data.shape}\n"
             f"Train/val sizes: {len(self.data_train)}, {len(self.data_val)}\n"
             f"Batch x stats: {(x.shape, x.dtype, x.min(), (x*1.0).mean(), (x*1.0).std(), x.max())}\n"
             f"Batch y stats: {(y.shape, y.dtype, y.min(), y.max())}\n"
             f"Pool size of labeled samples to do active learning from: {len(self.data_unlabelled)}\n"
         )
         return basic + data
-
-'''
-    def get_ds_length(self ,ds_name='unlabelled'):
-    
-        if ds_name=='unlabelled':
-            return len(self.data_unlabelled.data)
-        elif ds_name=='train':
-            return len(self.data_train.data)
-        elif ds_name=='test' :
-            return len(self.data_test.data)
-        elif ds_name=='val' :
-            return len(self.data_val.data)
-        else:
-            raise NameError('Unknown Dataset Name '+ds_name) 
-           
-
-    def expand_training_set(self, sample_idxs):
-
-        #get x_train, y_train
-        x_train=self.data_train.data
-        y_train=self.data_train.targets
-        #get unlabelled set
-        x_pool=self.data_unlabelled.data
-        y_pool=self.data_unlabelled.targets
-
-        # get new training examples
-        x_train_new = x_pool[sample_idxs]
-        y_train_new = y_pool[sample_idxs]
-
-        # remove the new examples from the unlabelled pool
-        mask = np.ones(x_pool.shape[0], bool)
-        mask[sample_idxs] = False
-        self.x_pool = x_pool[mask]
-        self.y_pool = y_pool[mask]
-
-
-        # add new examples to training set
-        self.x_train = np.concatenate([x_train, x_train_new])
-        self.y_train = np.concatenate([y_train, y_train_new])
-
-        self.data_train = BaseDataset(self.x_train, self.y_train, transform=self.transform)
-        self.data_test = BaseDataset(self.x_pool, self.y_pool, transform=self.transform) 
-        self.data_unlabelled=BaseDataset(self.x_pool, self.y_pool, transform=self.transform)
-        print('New train set size', len(self.x_train))
-        print('New unlabelled pool size', len(self.x_pool))
-
-
-    def get_activation_scores(self, model):
-
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        
-        # for some reason, lightning module is not yet on cuda, even if it was initialized that way --> transfer it
-        model = model.to(device)
-
-        # pytorch dataloader for batch-wise processing
-        all_samples = self.unlabelled_dataloader()
-
-        # initialize pytorch tensors to store activation scores
-        out_layer_1 = torch.Tensor().to(device)
-        out_layer_2 = torch.Tensor().to(device)
-        out_layer_3 = torch.Tensor().to(device)
-
-        model.eval()
-        with torch.no_grad():
-
-            # loop through batches in unlabelled pool
-            for batch_features, _ in all_samples:
-                
-                # move features to device
-                batch_features = batch_features.to(device)
-
-                # extract intermediate and final activations
-                out1, out2, out3 = model(batch_features, extract_intermediate_activations=True)
-
-                # store batch results
-                out_layer_1 = torch.cat([out_layer_1, out1])
-                out_layer_2 = torch.cat([out_layer_2, out2])
-                out_layer_3 = torch.cat([out_layer_3, out3])
-
-        return out_layer_1, out_layer_2, out_layer_3
-
-
-    def get_pool_probabilities(self, model, T=10):
-
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        
-        # for some reason, lightning module is not yet on cuda, even if it was initialized that way --> transfer it
-        model = model.to(device)
-
-        # pytorch dataloader for batch-wise processing
-        all_samples = self.unlabelled_dataloader()
-
-        if DEBUG_OUTPUT:
-            print("Processing pool of instances to generate probabilities")
-            print("(Note: Based on the pool size this takes a while. Will generate debug output every 5%.)\n")
-            five_percent = int(self.get_ds_length(ds_name="unlabelled") / all_samples.batch_size / 20)
-            i = 0
-            percentage_output = 5
-
-        # initialize pytorch tensor to store acquisition scores
-        all_outputs = torch.Tensor().to(device)
-
-        # set model to eval (non-training) modus and enable dropout layers
-        model.eval()
-        _enable_dropout(model)
-
-        if self.reduced_pool:
-            print("NOTE: Reduced pool dev parameter activated, will only process first batch")
-            all_samples = [next(all_samples._get_iterator())]
-
-
-        # process pool of instances batch wise
-        for batch_features, _ in all_samples:
-
-            with torch.no_grad():
-                outputs = torch.stack(
-                    [
-                        torch.softmax( # probabilities from logits
-                            model(batch_features.to(device)), dim=-1) # logits
-                        for t in range(T) # multiple calculations
-                    ]
-                , dim = -1)
-
-            all_outputs = torch.cat([all_outputs, outputs], dim = 0)
-
-            if DEBUG_OUTPUT:
-                i += 1
-                if i > five_percent:
-                    print(f"{percentage_output}% of samples in pool processed")
-                    percentage_output += 5
-                    i = 0
-
-        if DEBUG_OUTPUT:
-            print(f"100% of samples in pool processed\n")
-        
-        return all_outputs
-
-def _enable_dropout(model):
-    for each_module in model.modules():
-        if each_module.__class__.__name__.startswith('Dropout'):
-            each_module.train()
-'''
 
 
 if __name__ == "__main__":

--- a/active_learning/data/util.py
+++ b/active_learning/data/util.py
@@ -32,7 +32,7 @@ class BaseDataset(torch.utils.data.Dataset):
         target_transform: Callable = None,
     ) -> None:
         if len(data) != len(targets):
-            raise ValueError("Data and targets must be of equal length")
+            raise ValueError(f"Data and targets must be of equal length, but are {len(data)} and {len(targets)}")
         super().__init__()
         self.data = data
         self.targets = targets
@@ -81,23 +81,3 @@ def convert_strings_to_labels(strings: Sequence[str], mapping: Dict[str, int], l
         for ii, token in enumerate(tokens):
             labels[i, ii] = mapping[token]
     return labels
-
-
-def split_dataset(base_dataset: BaseDataset, fraction: float, seed: int) -> Tuple[BaseDataset, BaseDataset]:
-    """
-    Split input base_dataset into 2 base datasets, the first of size fraction * size of the base_dataset and the
-    other of size (1 - fraction) * size of the base_dataset.
-    """
-    split_a_size = int(fraction * len(base_dataset))
-    split_b_size = len(base_dataset) - split_a_size
-
-    # split to PyTorch's Subset
-    subset1, subset2 =  random_split(base_dataset, [split_a_size, split_b_size], generator=torch.Generator().manual_seed(seed))
-
-    # convert PyTorch's Subset to our BaseDataset
-    dataset1_x, dataset1_y = next(iter(DataLoader(base_dataset, sampler=subset1.indices, batch_size=len(subset1.indices))))
-    dataset2_x, dataset2_y = next(iter(DataLoader(base_dataset, sampler=subset2.indices, batch_size=len(subset2.indices))))
-    dataset1 = BaseDataset(dataset1_x, dataset1_y)
-    dataset2 = BaseDataset(dataset2_x, dataset2_y)
-
-    return dataset1, dataset2

--- a/active_learning/lit_models/base.py
+++ b/active_learning/lit_models/base.py
@@ -95,10 +95,12 @@ class BaseLitModel(pl.LightningModule):  # pylint: disable=too-many-ancestors
         self.one_cycle_total_steps = self.args.get("one_cycle_total_steps", ONE_CYCLE_TOTAL_STEPS)
         
         binary = self.args.get("binary", False)
+
         if binary:
             num_classes = 2
         else:
-            num_classes = 4
+            assert self.args.get("n_classes") is not None, "Neither 'binary' nor args parameter 'n_classes' was passed to BaseLitModel"
+            num_classes = self.args.get("n_classes")
 
         self.train_acc = Accuracy()
         self.val_acc = Accuracy()

--- a/active_learning/models/__init__.py
+++ b/active_learning/models/__init__.py
@@ -1,27 +1,2 @@
-'''
-from .mlp import MLP
-
-# Hide lines below until Lab 2
-from .cnn import CNN
-
-# Hide lines above until Lab 2
-
-# Hide lines below until Lab 3
-from .line_cnn_simple import LineCNNSimple
-from .line_cnn import LineCNN
-from .line_cnn_lstm import LineCNNLSTM
-
-# Hide lines above until Lab 3
-
-# Hide lines below until Lab 4
-from .line_cnn_transformer import LineCNNTransformer
-
-# Hide lines above until Lab 4
-
-# Hide lines below until Lab 7
-from .resnet_transformer import ResnetTransformer
-
-# Hide lines above until Lab 7
-'''
-# added by active-learning-project
 from .resnet_classifier import ResnetClassifier
+from .mnist_resnet_classifier import MNISTResnetClassifier

--- a/active_learning/models/mnist_resnet_classifier.py
+++ b/active_learning/models/mnist_resnet_classifier.py
@@ -1,0 +1,125 @@
+import argparse
+from typing import Any, Dict
+import torch
+import torch.nn as nn
+import torchvision.transforms as tt
+import torchvision
+import warnings
+
+PRETRAINED = True
+NUM_CLASSES = 10
+NUM_CHANNELS = 11
+DROPOUT = True
+DROPOUT_PROB = 0.5
+DROPOUT_HIDDEN_DIM = 512
+BINARY = False
+
+class MNISTResnetClassifier(nn.Module):
+    """Classify an image of arbitrary size through a (pretrained) ResNet network"""
+
+    def __init__(self, data_config: Dict[str, Any] = None, args: argparse.Namespace = None) -> None:
+        super().__init__()
+        self.args = vars(args) if args is not None else {}
+
+        n_classes = self.args.get("n_classes", NUM_CLASSES)
+        pretrained = self.args.get("pretrained", PRETRAINED)
+        self.dropout = self.args.get("dropout", DROPOUT)
+        binary = self.args.get("binary", BINARY)
+
+        # override values if binary is specified
+        if binary == True:
+            n_classes = 2
+            print("Overriding n_classes parameter, setting n_classes to 2")
+
+        # base ResNet model
+        self.resnet = torchvision.models.resnet50(pretrained=pretrained)
+
+        # preprocessing for MNIST
+        #self.preprocess = tt.Compose([
+        #    tt.ToTensor(), 
+        #    tt.Resize((224, 224)), 
+        #    tt.Normalize((0.1307,), (0.3081,))
+        #    ])
+
+        # changing the architecture of the laster layers
+        # if dropout is activated, add an additional fully connected layer with dropout before the last layer
+        # split classification head into different parts to extract intermediate activations
+        if self.dropout:    
+        
+            # first fully connected layer
+            self.resnet.fc = nn.Linear(self.resnet.fc.in_features, self.resnet.fc.in_features) # additional fc layer
+
+            # first part of additional classification head
+            self.head_part_1 = nn.Sequential(
+                nn.BatchNorm1d(self.resnet.fc.in_features), # adding batchnorm
+                nn.ReLU(), # additional nonlinearity
+                nn.Dropout(DROPOUT_PROB), # additional dropout layer
+                nn.Linear(self.resnet.fc.in_features, DROPOUT_HIDDEN_DIM) # additional fc layer
+            )
+
+            # second part of classification head
+            self.head_part_2 = nn.Sequential(
+                nn.BatchNorm1d(DROPOUT_HIDDEN_DIM), # adding batchnorm
+                nn.ReLU(), # additional nonlinearity
+                nn.Dropout(DROPOUT_PROB), # additional dropout layer
+                nn.Linear(DROPOUT_HIDDEN_DIM, n_classes) # same fc layer as we had before
+            )
+
+        # otherwise just adapt no. of classes in last fully-connected layer
+        else:
+            self.resnet.fc = nn.Linear(self.resnet.fc.in_features, n_classes)
+
+        print("Adapting first convolutional layer to only one input channel\n")
+        self.resnet.conv1 = nn.Conv2d(
+            in_channels=1, 
+            out_channels=self.resnet.conv1.out_channels, 
+            kernel_size=(7, 7), 
+            stride=(2, 2), 
+            padding=(3, 3), 
+            bias=False)
+
+
+    def forward(self, x: torch.Tensor, extract_intermediate_activations: bool = False) -> torch.Tensor:
+        """
+        Args:
+        x
+            (B, C, H, W) tensor (H, W can be arbitrary, will be reshaped by reprocessing)
+
+        Returns
+        -------
+        torch.Tensor
+            (B, C) tensor
+        """
+        if self.dropout:
+        
+            if extract_intermediate_activations:
+
+                #x = self.preprocess(x)
+                x = self.resnet(x)
+                y = self.head_part_1(x)
+                z = self.head_part_2(y)
+
+                return x, y, z
+
+            else:
+
+                #x = self.preprocess(x)
+                x = self.resnet(x)
+                x = self.head_part_1(x)
+                x = self.head_part_2(x)
+
+                return x
+            
+        else:
+
+            #x = x.float()
+            #x = self.preprocess(x)
+            x = self.resnet(x)
+
+            return x
+
+    def add_to_argparse(parser):
+        parser.add_argument("--pretrained", type=bool, default=PRETRAINED)
+        parser.add_argument("--n_classes", type=int, default=NUM_CLASSES)
+        parser.add_argument("--dropout", type=bool, default=DROPOUT)
+        return parser

--- a/training/run_experiment.py
+++ b/training/run_experiment.py
@@ -202,11 +202,11 @@ def main():
     lit_model_class = lit_models.BaseLitModel
 
     # get info about scenario for logging
-    if args.binary:
+    if "binary" in args and args.binary:
         class_scenario = "_binary"
     else:
         class_scenario = "_multi-class"
-    if args.rgb:
+    if "rgb" in args and args.rgb:
         channel_scenario = "_rgb"
     else:
         channel_scenario = "_all-channels"


### PR DESCRIPTION
New:
- `MNIST` data class added that gets data via TorchVision
- `MNISTResnetClassifier` added that is almost the same as the one we used so far, but with another preprocessing and no RGB functionality

Refactoring needed to get new stuff above working:
- General methods `get_ds_length`, `expand_training_set`, `get_activation_scores`, `get_pool_probabilities`, `_enable_dropout` removed from `DroughtWatch` and added to `BaseDataModule` (so they are available to other data sets as well)
- Fix in `BaseLitModel`: Don't set num_classes hardcoded to 4, but to the num_classes args parameter (to enable using it with datasets that don't have 4 classes by default)
- Refactor `if` statements in `run_experiment.py` to make "binary" and "rgb" optional args parameter for model classes

Refactoring along the way:
- Unused method `split_dataset` removed from `data/util.py`
- Random comments removed that we took over from the class code base