### PR TITLE
ATL methods fixed for MNIST

### DIFF
--- a/active_learning/lit_models/base.py
+++ b/active_learning/lit_models/base.py
@@ -169,7 +169,7 @@ class BaseLitModel(pl.LightningModule):  # pylint: disable=too-many-ancestors
             self.log("train_size", self.trainer.datamodule.get_ds_length('train'), on_step=False, on_epoch=True, prog_bar=False)
 
         # store validation predictions
-        if len(self.val_predictions) in [0, 10778]:
+        if len(self.val_predictions) in [0, 10000]:
             self.val_predictions = logits.detach()
         else:
             self.val_predictions = torch.cat([self.val_predictions, logits.detach()])

--- a/training/run_experiment.py
+++ b/training/run_experiment.py
@@ -153,8 +153,7 @@ def _finetune_and_sample(lit_model, data, new_train_dataloader, new_val_dataload
     lit_model.logging = False
 
     # initialize trainer
-    early_stopping_callback = pl.callbacks.EarlyStopping(monitor="val_loss", mode="min", patience=2)
-    trainer = pl.Trainer(gpus=args.gpus, callbacks=[early_stopping_callback], progress_bar_refresh_rate=30, max_epochs=10, num_sanity_val_steps=0)
+    trainer = pl.Trainer(gpus=args.gpus, progress_bar_refresh_rate=30, max_epochs=10, num_sanity_val_steps=0)
     trainer.tune(lit_model, train_dataloader=new_train_dataloader, val_dataloaders=new_val_dataloader)
 
     # fit trainer on new data


### PR DESCRIPTION
Two changes:
- removed early stopping for active transfer learning due to conflict of not logging but logging being required for early stopping
- changed validation set size in base.py according to MNIST 